### PR TITLE
Add Calibration Toolkit

### DIFF
--- a/calibration_application_config.yml
+++ b/calibration_application_config.yml
@@ -1,0 +1,8 @@
+source:
+  folder: tests/data/2025
+
+work-folder: .work
+
+destination:
+  folder: output/
+  filename: L2.cdf

--- a/calibration_config.yml
+++ b/calibration_config.yml
@@ -1,0 +1,8 @@
+source:
+  folder: tests/data/2025
+
+work-folder: .work
+
+destination:
+  folder: output/
+  filename: calibration.json

--- a/poetry.lock
+++ b/poetry.lock
@@ -89,13 +89,13 @@ typing = ["typing-extensions (>=4.0.0)"]
 
 [[package]]
 name = "astropy-iers-data"
-version = "0.2024.7.22.0.34.13"
+version = "0.2024.7.29.0.32.7"
 description = "IERS Earth Rotation and Leap Second tables for the astropy core package"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "astropy_iers_data-0.2024.7.22.0.34.13-py3-none-any.whl", hash = "sha256:567a6cb261dd62f60862ee8d38e70fb2c88dfad03e962bc8138397a22e33003d"},
-    {file = "astropy_iers_data-0.2024.7.22.0.34.13.tar.gz", hash = "sha256:9bbb4bfc28bc8e834a6b3946a312ce3490c285abeab8fd9b1e98b11fdee6f92c"},
+    {file = "astropy_iers_data-0.2024.7.29.0.32.7-py3-none-any.whl", hash = "sha256:7c8fb523731f6c2c039c112be089c998202020234d2a6155a1f3620b4cfbf24d"},
+    {file = "astropy_iers_data-0.2024.7.29.0.32.7.tar.gz", hash = "sha256:32967816e4758603b571303ea3c8a836570aacb10f9bb258154f10d2913faf6d"},
 ]
 
 [package.extras]
@@ -246,6 +246,25 @@ files = [
 
 [package.dependencies]
 bitarray = ">=2.9.0,<3.0.0"
+
+[[package]]
+name = "cdflib"
+version = "1.3.1"
+description = "A python CDF reader toolkit"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "cdflib-1.3.1-py3-none-any.whl", hash = "sha256:115494bfffd23b92c41629d5fcfdefab77112a4d9d1ff6023f87c5444d2e9aeb"},
+    {file = "cdflib-1.3.1.tar.gz", hash = "sha256:7bb296e02ac7c47536c43bcc20d24796bfd9d4ec39490ec74953972203f26913"},
+]
+
+[package.dependencies]
+numpy = ">=1.21"
+
+[package.extras]
+dev = ["ipython", "pre-commit"]
+docs = ["astropy", "netcdf4", "sphinx", "sphinx-automodapi", "sphinx-copybutton", "sphinx-rtd-theme", "xarray"]
+tests = ["astropy", "h5netcdf", "hypothesis", "netcdf4", "pytest (>=3.9)", "pytest-cov", "pytest-remotedata", "xarray"]
 
 [[package]]
 name = "certifi"
@@ -1404,13 +1423,13 @@ files = [
 
 [[package]]
 name = "setuptools"
-version = "71.1.0"
+version = "72.0.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "setuptools-71.1.0-py3-none-any.whl", hash = "sha256:33874fdc59b3188304b2e7c80d9029097ea31627180896fb549c578ceb8a0855"},
-    {file = "setuptools-71.1.0.tar.gz", hash = "sha256:032d42ee9fb536e33087fb66cac5f840eb9391ed05637b3f2a76a7c8fb477936"},
+    {file = "setuptools-72.0.0-py3-none-any.whl", hash = "sha256:98b4d786a12fadd34eabf69e8d014b84e5fc655981e4ff419994700434ace132"},
+    {file = "setuptools-72.0.0.tar.gz", hash = "sha256:5a0d9c6a2f332881a0153f629d8000118efd33255cfa802757924c53312c76da"},
 ]
 
 [package.extras]
@@ -1683,4 +1702,4 @@ viz = ["matplotlib", "nc-time-axis", "seaborn"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.13"
-content-hash = "b88a488487eb736be738b1d142b111f0aced830ba5c887368835a063c47ec1e4"
+content-hash = "3f8ff12d4fd300e1ffae7733880c456882114cf2decc722196d993e5e0aa285a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ requests = "^2.32.3"
 pandas = "^2.2.2"
 imap-data-access = "^0.7.0"
 astropy = "^6.1.2"
+cdflib = "^1.3.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.1"

--- a/src/imap_mag/appConfig.py
+++ b/src/imap_mag/appConfig.py
@@ -1,6 +1,7 @@
 """App configuration module."""
 
 from pathlib import Path
+from typing import Optional
 
 from pydantic import BaseModel
 from pydantic.config import ConfigDict
@@ -27,7 +28,7 @@ class AppConfig(BaseModel):
     source: Source
     work_folder: Path = Path(".work")
     destination: Destination
-    packet_definition: PacketDefinition
+    packet_definition: Optional[PacketDefinition] = None
 
     # pydantic configuration to allow hyphenated fields
     model_config = ConfigDict(alias_generator=hyphenize)

--- a/src/imap_mag/main.py
+++ b/src/imap_mag/main.py
@@ -16,9 +16,23 @@ import yaml
 
 from src.imap_db.model import File
 
+from src.mag_toolkit import CDFLoader
+from src.mag_toolkit.calibration.CalibrationApplicator import CalibrationApplicator
+from src.mag_toolkit.calibration.calibrationFormatProcessor import (
+    CalibrationFormatProcessor,
+)
+from src.mag_toolkit.calibration.Calibrator import (
+    Calibrator,
+    CalibratorType,
+    SpinAxisCalibrator,
+    SpinPlaneCalibrator,
+)
+
 # app code
 from . import DB, SDC, appConfig, appLogging, appUtils, imapProcessing, webPODA
 from .sdcApiClient import SDCApiClient
+from src import appConfig, appLogging, imapProcessing
+
 
 app = typer.Typer()
 globalState = {"verbose": False}
@@ -81,21 +95,7 @@ def hello(name: str):
     print(f"Hello {name}")
 
 
-# E.g  imap-mag process --config config.yml solo_L2_mag-rtn-ll-internal_20240210_V00.cdf
-@app.command()
-def process(
-    file: Annotated[
-        str, typer.Argument(help="The file name or pattern to match for the input file")
-    ],
-    config: Annotated[Path, typer.Option()] = Path("config.yml"),
-):
-    """Sample processing job."""
-    # TODO: semantic logging
-    # TODO: handle file system/cloud files - abstraction layer needed for files
-    # TODO: move shared logic to a library
-
-    configFile: appConfig.AppConfig = commandInit(config)
-
+def prepareWorkFile(file, configFile):
     logging.debug(f"Grabbing file matching {file} in {configFile.source.folder}")
 
     # get all files in \\RDS.IMPERIAL.AC.UK\rds\project\solarorbitermagnetometer\live\SO-MAG-Web\quicklooks_py\
@@ -130,6 +130,26 @@ def process(
     workFile = Path(configFile.work_folder, files[0].name)
     logging.debug(f"Copying {files[0]} to {workFile}")
     workFile = Path(shutil.copy2(files[0], configFile.work_folder))
+
+    return workFile
+
+
+# E.g  imap-mag process --config config.yml solo_L2_mag-rtn-ll-internal_20240210_V00.cdf
+@app.command()
+def process(
+    config: Annotated[Path, typer.Option()] = Path("config.yml"),
+    file: str = typer.Argument(
+        help="The file name or pattern to match for the input file"
+    ),
+):
+    """Sample processing job."""
+    # TODO: semantic logging
+    # TODO: handle file system/cloud files - abstraction layer needed for files
+    # TODO: move shared logic to a library
+
+    configFile: appConfig.AppConfig = commandInit(config)
+
+    workFile = prepareWorkFile(file, configFile)
 
     # TODO: do something with the data!
     fileProcessor = imapProcessing.dispatchFile(workFile)
@@ -228,6 +248,63 @@ def fetch_science(
 
     # for file in files:
     #     appUtils.copyFileToDestination(file, configFile.destination)
+
+
+# imap-mag calibrate --config calibration_config.yml --method SpinAxisCalibrator imap_mag_l1b_norm-mago_20250502_v000.cdf
+@app.command()
+def calibrate(
+    config: Annotated[Path, typer.Option()] = Path("calibration_config.yml"),
+    method: Annotated[CalibratorType, typer.Option()] = "SpinAxisCalibrator",
+    input: str = typer.Argument(
+        help="The file name or pattern to match for the input file"
+    ),
+):
+    # TODO: Define specific calibration configuration
+    # Using AppConfig for now to piggyback off of configuration
+    # verification and work area setup
+    configFile: appConfig.AppConfig = commandInit(config)
+
+    workFile = prepareWorkFile(input, configFile)
+    calibrator: Calibrator
+
+    match method:
+        case CalibratorType.SPINAXIS:
+            calibrator = SpinAxisCalibrator()
+        case CalibratorType.SPINPLANE:
+            calibrator = SpinPlaneCalibrator()
+
+    inputData = CDFLoader.load_cdf(workFile)
+    calibration = calibrator.generateCalibration(inputData)
+
+    tempOutputFile = os.path.join(configFile.work_folder, "calibration.json")
+
+    result = CalibrationFormatProcessor.writeToFile(calibration, tempOutputFile)
+
+    appUtils.copyFileToDestination(result, configFile.destination)
+
+
+# imap-mag apply --config calibration_application_config.yml --calibration calibration.json imap_mag_l1a_norm-mago_20250502_v000.cdf
+@app.command()
+def apply(
+    config: Annotated[Path, typer.Option()] = Path(
+        "calibration_application_config.yml"
+    ),
+    calibration: Annotated[str, typer.Option()] = "calibration.json",
+    input: str = typer.Argument(
+        help="The file name or pattern to match for the input file"
+    ),
+):
+    configFile: appConfig.AppConfig = commandInit(config)
+
+    workDataFile = prepareWorkFile(input, configFile)
+    workCalibrationFile = prepareWorkFile(calibration, configFile)
+    workOutputFile = os.path.join(configFile.work_folder, "l2_data.cdf")
+
+    applier = CalibrationApplicator()
+
+    L2_file = applier.apply(workCalibrationFile, workDataFile, workOutputFile)
+
+    appUtils.copyFileToDestination(L2_file, configFile.destination)
 
 
 @app.callback()

--- a/src/imap_mag/main.py
+++ b/src/imap_mag/main.py
@@ -15,7 +15,6 @@ import typer
 import yaml
 
 from src.imap_db.model import File
-
 from src.mag_toolkit import CDFLoader
 from src.mag_toolkit.calibration.CalibrationApplicator import CalibrationApplicator
 from src.mag_toolkit.calibration.calibrationFormatProcessor import (
@@ -28,11 +27,8 @@ from src.mag_toolkit.calibration.Calibrator import (
     SpinPlaneCalibrator,
 )
 
-# app code
 from . import DB, SDC, appConfig, appLogging, appUtils, imapProcessing, webPODA
 from .sdcApiClient import SDCApiClient
-from src import appConfig, appLogging, imapProcessing
-
 
 app = typer.Typer()
 globalState = {"verbose": False}

--- a/src/mag_toolkit/CDFLoader.py
+++ b/src/mag_toolkit/CDFLoader.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+from cdflib import xarray
+
+
+def load_cdf(inputPath: Path):
+    """Wraps cdlibs xarray reader."""
+    if inputPath.is_file():
+        return xarray.cdf_to_xarray(inputPath)
+    else:
+        raise FileExistsError()
+
+
+def write_cdf(dataset, outputPath: Path):
+    """Wraps cdflib xarray writer."""
+    xarray.xarray_to_cdf(dataset, outputPath)

--- a/src/mag_toolkit/calibration/CalibrationApplicator.py
+++ b/src/mag_toolkit/calibration/CalibrationApplicator.py
@@ -1,0 +1,46 @@
+import logging
+from pathlib import Path
+
+import numpy as np
+
+from src.mag_toolkit.calibration.CalibrationExceptions import CalibrationValidityError
+from src.mag_toolkit.calibration.calibrationFormat import CalibrationFormat
+from src.mag_toolkit.calibration.calibrationFormatProcessor import (
+    CalibrationFormatProcessor,
+)
+from src.mag_toolkit.CDFLoader import load_cdf, write_cdf
+
+
+class CalibrationApplicator:
+    def apply(self, calibrationFile, dataFile, outputFile) -> Path:
+        """Currently operating on unprocessed data."""
+        data = load_cdf(dataFile)
+        calibrationCollection: CalibrationFormat = (
+            CalibrationFormatProcessor.loadFromPath(calibrationFile)
+        )
+
+        logging.info("Loaded calibration file and data file")
+
+        try:
+            self.checkValidity(data, calibrationCollection)
+        except CalibrationValidityError as e:
+            logging.info(f"{e} -> continuing application of calibration regardless")
+
+        logging.info("Dataset and calibration file deemed compatible")
+
+        for eachCal in calibrationCollection.calibrations:
+            data.vectors[0] = data.vectors[0] + eachCal.offsets.X
+            data.vectors[1] = data.vectors[1] + eachCal.offsets.Y
+            data.vectors[2] = data.vectors[2] + eachCal.offsets.Z
+
+        write_cdf(data, outputFile)
+
+        return outputFile
+
+    def checkValidity(self, data, calibrationCollection):
+        # check for time validity
+        if data.epoch[0] < np.datetime64(
+            calibrationCollection.valid_start
+        ) or data.epoch[1] > np.datetime64(calibrationCollection.valid_end):
+            logging.debug("Data outside of calibration validity range")
+            raise CalibrationValidityError("Data outside of calibration validity range")

--- a/src/mag_toolkit/calibration/CalibrationExceptions.py
+++ b/src/mag_toolkit/calibration/CalibrationExceptions.py
@@ -1,0 +1,2 @@
+class CalibrationValidityError(Exception):
+    pass

--- a/src/mag_toolkit/calibration/Calibrator.py
+++ b/src/mag_toolkit/calibration/Calibrator.py
@@ -1,0 +1,78 @@
+from abc import ABC, abstractmethod
+from datetime import datetime
+from enum import Enum
+
+import numpy as np
+
+from src.mag_toolkit.calibration import MatlabWrapper
+from src.mag_toolkit.calibration.calibrationFormat import (
+    CalibrationFormat,
+    OffsetCollection,
+    SingleCalibration,
+    Unit,
+)
+
+
+class CalibratorType(str, Enum):
+    SPINAXIS = ("SpinAxisCalibrator",)
+    SPINPLANE = "SpinPlaneCalibrator"
+
+
+class Calibrator(ABC):
+    def generateOffsets(self, data) -> OffsetCollection:
+        """Generates a set of offsets."""
+        (timestamps, x_offsets, y_offsets, z_offsets) = self.runCalibration(data)
+
+        offsetCollection = OffsetCollection(X=x_offsets, Y=y_offsets, Z=z_offsets)
+
+        sensor_name = "MAGO"
+
+        singleCalibration = SingleCalibration(
+            timestamps=timestamps,
+            offsets=offsetCollection,
+            units=Unit.NT,
+            instrument=sensor_name,
+            creation_timestamp=datetime.now(),
+            method=str(self.name),
+        )
+        return singleCalibration
+
+    def generateCalibration(self, data) -> CalibrationFormat:
+        singleCalibration = self.generateOffsets(data)
+        calibration = CalibrationFormat(
+            valid_start=singleCalibration.timestamps[0],
+            valid_end=singleCalibration.timestamps[-1],
+            calibrations=[singleCalibration],
+        )
+        return calibration
+
+    @abstractmethod
+    def runCalibration(self, data):
+        """Calibration that generates offsets and timestamps."""
+
+
+class SpinAxisCalibrator(Calibrator):
+    def __init__(self):
+        self.name = CalibratorType.SPINAXIS
+
+    def runCalibration(self, data):
+        (timestamps, z_offsets) = MatlabWrapper.simulateSpinAxisCalibration(data)
+
+        return (
+            timestamps,
+            np.zeros(len(z_offsets)),
+            np.zeros(len(z_offsets)),
+            z_offsets,
+        )
+
+
+class SpinPlaneCalibrator(Calibrator):
+    def __init__(self):
+        self.name = CalibratorType.SPINPLANE
+
+    def runCalibration(self, data):
+        (timestamps, x_offsets, y_offsets) = (
+            MatlabWrapper.simulateSpinPlaneCalibration()
+        )
+
+        return (timestamps, x_offsets, y_offsets, np.zeros(len(x_offsets)))

--- a/src/mag_toolkit/calibration/MatlabWrapper.py
+++ b/src/mag_toolkit/calibration/MatlabWrapper.py
@@ -1,0 +1,16 @@
+from datetime import datetime
+
+
+def simulateSpinAxisCalibration(xarray):
+    timestamps = [datetime(2022, 3, 3)]
+    offsets = [3.256]
+
+    return (timestamps, offsets)
+
+
+def simulateSpinPlaneCalibration(xarray):
+    timestamps = [datetime(2022, 3, 3)]
+    offsets_x = [3.256]
+    offsets_y = [2.76]
+
+    return (timestamps, offsets_x, offsets_y)

--- a/src/mag_toolkit/calibration/MatlabWrapper.py
+++ b/src/mag_toolkit/calibration/MatlabWrapper.py
@@ -1,16 +1,38 @@
 from datetime import datetime
 
+import numpy as np
+from pydantic import BaseModel
 
-def simulateSpinAxisCalibration(xarray):
+
+class BasicCalibration(BaseModel):
+    timestamps: list[datetime]
+    x_offsets: list[float]
+    y_offsets: list[float]
+    z_offsets: list[float]
+
+
+def simulateSpinAxisCalibration(xarray) -> BasicCalibration:
+    # TODO: Transfer to MATLAB to get spin axis offsets
     timestamps = [datetime(2022, 3, 3)]
     offsets = [3.256]
 
-    return (timestamps, offsets)
+    return BasicCalibration(
+        timestamps=timestamps,
+        x_offsets=np.zeros(len(offsets)),
+        y_offsets=np.zeros(len(offsets)),
+        z_offsets=offsets,
+    )
 
 
 def simulateSpinPlaneCalibration(xarray):
+    # TODO: Transfer to MATLAB to get spin plane offsets
     timestamps = [datetime(2022, 3, 3)]
     offsets_x = [3.256]
     offsets_y = [2.76]
 
-    return (timestamps, offsets_x, offsets_y)
+    return BasicCalibration(
+        timestamps=timestamps,
+        x_offsets=offsets_x,
+        y_offsets=offsets_y,
+        z_offsets=np.zeros(len(offsets_x)),
+    )

--- a/src/mag_toolkit/calibration/calibrationFormat.py
+++ b/src/mag_toolkit/calibration/calibrationFormat.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from enum import Enum
-from typing import Optional, Self
+from typing import Optional
 
 from pydantic import BaseModel, model_validator
 
@@ -22,7 +22,7 @@ class OffsetCollection(BaseModel):
     Z: list[float]
 
     @model_validator(mode="after")
-    def check_lengths_match(self) -> Self:
+    def check_lengths_match(self):
         if (
             len(self.X) != len(self.Y)
             or len(self.Y) != len(self.Z)

--- a/src/mag_toolkit/calibration/calibrationFormat.py
+++ b/src/mag_toolkit/calibration/calibrationFormat.py
@@ -1,0 +1,48 @@
+from datetime import datetime
+from enum import Enum
+from typing import Optional, Self
+
+from pydantic import BaseModel, model_validator
+
+
+class Unit(Enum):
+    NT = "nT"
+    UT = "uT"
+    T = "T"
+
+
+class Instrument(Enum):
+    MAGO = "MAGO"
+    MAGI = "MAGI"
+
+
+class OffsetCollection(BaseModel):
+    X: list[float]
+    Y: list[float]
+    Z: list[float]
+
+    @model_validator(mode="after")
+    def check_lengths_match(self) -> Self:
+        if (
+            len(self.X) != len(self.Y)
+            or len(self.Y) != len(self.Z)
+            or len(self.X) != len(self.Z)
+        ):
+            raise ValueError("Length of offset lists do not match")
+        return self
+
+
+class SingleCalibration(BaseModel):
+    timestamps: list[datetime]
+    offsets: OffsetCollection
+    units: Unit
+    instrument: Instrument
+    creation_timestamp: datetime
+    method: str
+    comment: Optional[str] = None
+
+
+class CalibrationFormat(BaseModel):
+    valid_start: datetime
+    valid_end: datetime
+    calibrations: list[SingleCalibration]

--- a/src/mag_toolkit/calibration/calibrationFormatProcessor.py
+++ b/src/mag_toolkit/calibration/calibrationFormatProcessor.py
@@ -1,0 +1,51 @@
+import os
+from pathlib import Path
+
+import yaml
+from pydantic import ValidationError
+
+from src.mag_toolkit.calibration.calibrationFormat import CalibrationFormat
+
+
+class CalibrationFormatProcessor:
+    def loadFromPath(calibrationPath: Path) -> CalibrationFormat:
+        try:
+            as_dict = yaml.safe_load(open(calibrationPath))
+            model = CalibrationFormat(**as_dict)
+            return model
+        except ValidationError as e:
+            print(e)
+            return None
+        except FileNotFoundError as e:
+            print(e)
+            return None
+
+    def loadFromDict(calibrationDict: dict) -> CalibrationFormat:
+        try:
+            model = CalibrationFormat(**calibrationDict)
+            return model
+        except ValidationError as e:
+            print(e)
+            return None
+
+    def getWriteable(CalibrationFormat: CalibrationFormat):
+        json = CalibrationFormat.model_dump_json()
+
+        return json
+
+    def writeToFile(
+        CalibrationFormat: CalibrationFormat, filepath: Path, createDirectory=False
+    ):
+        json = CalibrationFormat.model_dump_json()
+
+        if createDirectory:
+            os.makedirs(os.path.dirname(filepath), exist_ok=True)
+
+        try:
+            with open(filepath, "w+") as f:
+                f.write(json)
+        except Exception as e:
+            print(e)
+            print(f"Failed to write calibration to {filepath}")
+
+        return filepath

--- a/tests/data/2025/calibration.json
+++ b/tests/data/2025/calibration.json
@@ -1,0 +1,27 @@
+{
+    "calibrations": [
+        {
+            "comment": null,
+            "creation_timestamp": "2024-07-26T16:51:58.212401",
+            "instrument": "MAGO",
+            "method": "CalibratorType.SPINAXIS",
+            "offsets": {
+                "X": [
+                    0.0
+                ],
+                "Y": [
+                    0.0
+                ],
+                "Z": [
+                    3.256
+                ]
+            },
+            "timestamps": [
+                "2022-03-03T00:00:00"
+            ],
+            "units": "nT"
+        }
+    ],
+    "valid_end": "2022-03-03T00:00:00",
+    "valid_start": "2022-03-03T00:00:00"
+}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -96,4 +96,38 @@ def test_fetch_binary_downloads_hk_from_webpoda(tidyDataFolders):
 
     # Verify.
     assert result.exit_code == 0
-    assert Path("output/power.pkts").exists()
+    assert Path("output/power.pkts").exists()  #
+
+
+def test_calibration_creates_calibration_file():
+    result = runner.invoke(
+        app,
+        [
+            "calibrate",
+            "--config",
+            "calibration_config.yml",
+            "--method",
+            "SpinAxisCalibrator",
+            "imap_mag_l1a_norm-mago_20250502_v000.cdf",
+        ],
+    )
+    assert result.exit_code == 0
+    assert Path("output/calibration.json").exists()
+
+
+def test_application_creates_L2_file():
+    result = runner.invoke(
+        app,
+        [
+            "apply",
+            "--config",
+            "calibration_application_config.yml",
+            "--calibration",
+            "calibration.json",
+            "imap_mag_l1a_norm-mago_20250502_v000.cdf",
+        ],
+    )
+
+    print("\n" + str(result.stdout))
+    assert result.exit_code == 0
+    assert Path("output/L2.cdf").exists()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -99,7 +99,7 @@ def test_fetch_binary_downloads_hk_from_webpoda(tidyDataFolders):
     assert Path("output/power.pkts").exists()  #
 
 
-def test_calibration_creates_calibration_file():
+def test_calibration_creates_calibration_file(tidyDataFolders):
     result = runner.invoke(
         app,
         [
@@ -115,7 +115,7 @@ def test_calibration_creates_calibration_file():
     assert Path("output/calibration.json").exists()
 
 
-def test_application_creates_L2_file():
+def test_application_creates_L2_file(tidyDataFolders):
     result = runner.invoke(
         app,
         [


### PR DESCRIPTION
Adds two commands to the IMAP MAG CLI that calibrate, and apply calibrations.

These use calibration tools from inside mag toolkit, packaged within the app to simplify integration for now.

Calibrations are not real, but basically form a skeleton inside of which real calibration and application could be performed.