### PR TITLE
ci(fix): Pre-commit autoupdate permissions

### DIFF
--- a/.github/workflows/pre-commit_autoupdate.yaml
+++ b/.github/workflows/pre-commit_autoupdate.yaml
@@ -20,7 +20,6 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: update/pre-commit-hooks
-          base: dev
           title: "Chore: Update Pre-Commit Hooks"
           commit-message: "chore: update pre-commit hooks"
           body: Update versions of pre-commit hooks to latest version.


### PR DESCRIPTION
`pre-commit` auto-update was failing because of a wrong base branch (oops!) and it would also fail because of missing permissions (as I noticed in other repos):
https://github.com/ImperialCollegeLondon/imap-pipeline-core/actions/runs/16663224839/job/47164667490