### PR TITLE
fix: add additional test assertions for correct metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ concurrency:
 
 env:
   PREFERED_PYTHON_VERSION: "3.12"
-  CALIBRATION_TAG: "fix/noop-not-adding-science-to-metadata"
+  CALIBRATION_TAG: "v0.1.5"
   MLM_LICENSE_TOKEN: ${{secrets.MLM_LICENSE_TOKEN }}
   CALIBRATION_CODE_LOCATION: "src/matlab/calibration"
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ concurrency:
 
 env:
   PREFERED_PYTHON_VERSION: "3.12"
-  CALIBRATION_TAG: "v0.1.4"
+  CALIBRATION_TAG: "fix/noop-not-adding-science-to-metadata"
   MLM_LICENSE_TOKEN: ${{secrets.MLM_LICENSE_TOKEN }}
   CALIBRATION_CODE_LOCATION: "src/matlab/calibration"
 jobs:

--- a/deploy/MATLAB-Dockerfile
+++ b/deploy/MATLAB-Dockerfile
@@ -79,7 +79,7 @@ COPY --from=matlab_install /opt/matlab /opt/matlab
 COPY --from=compile-image /home/${IMAP_USERNAME}/.local /home/${IMAP_USERNAME}/.local
 COPY dist/docker /app
 
-RUN apt-get update && apt-get install -y libxt6 libgdk-pixbuf2.0-0
+RUN apt-get update && apt-get install -y libxt6 libgdk-pixbuf-2.0-0
 
 RUN adduser -u ${IMAP_USERID} --disabled-password --gecos "" ${IMAP_USERNAME} && \
     chown -R ${IMAP_USERNAME} /app && \

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -338,6 +338,11 @@ def test_empty_calibration_layer_is_created_with_offsets_for_every_vector(
         noop_layer = json.load(f)
 
     assert noop_layer["method"] == "noop"
+    assert len(noop_layer["metadata"]["science"]) == 1
+    assert (
+        noop_layer["metadata"]["science"][0]
+        == "imap_mag_l1c_norm-mago_20250421_v001.cdf"
+    )
     assert len(noop_layer["values"]) == 100
 
     real_timestamps = [
@@ -396,6 +401,11 @@ def test_gradiometry_calibration_layer_is_created_with_correct_offsets_for_one_v
         grad_layer = json.load(f)
 
     assert grad_layer["method"] == "gradiometer"
+    assert len(grad_layer["metadata"]["science"]) == 1
+    assert (
+        grad_layer["metadata"]["science"][0]
+        == "imap_mag_l1c_norm-mago_20260930_v001.cdf"
+    )
     assert len(grad_layer["values"]) == 99
     assert np.datetime64(grad_layer["values"][0]["time"]) == np.datetime64(
         "2026-09-30T00:00:08.285840"


### PR DESCRIPTION
Tests were not testing for the correct science in the layer files. Added tests to ensure this does not fail again.

Needs to also include an update to the calibration code to match an updated version.

https://github.com/ImperialCollegeLondon/IMAP_MAG_Experimental_Calibration/pull/5