### PR TITLE
feat: WEB PODA service ID (flight/preflight) is configurable

### DIFF
--- a/imap-mag-config.yaml
+++ b/imap-mag-config.yaml
@@ -11,7 +11,7 @@ packet_definition: 'xtce/tlm_20241024.xml'
 # Command specific configuration:
 fetch_binary:
     api:
-        url_base: 'https://lasp.colorado.edu/ops/imap/poda/dap2/'
+        url_base: 'https://lasp.colorado.edu/ops/imap/poda/dap2/packets/SID2/'
         auth_code:
     work_sub_folder:
     publish_to_data_store: true

--- a/src/imap_mag/client/WebPODA.py
+++ b/src/imap_mag/client/WebPODA.py
@@ -118,13 +118,14 @@ class WebPODA:
         end_value: str = end_date.strftime("%Y-%m-%dT%H:%M:%S")
         time_var = "ert" if ert else "time"
 
-        url = (
+        # default to the pre-launch system ID if one is not passed in the URL
+        url_base: str = (
             f"{urllib.parse.urljoin(self.__webpoda_url, 'packets/SID2/')}"
-            f"{packet}.{extension}?"
-            f"{time_var}%3E={start_value}&"
-            f"{time_var}%3C{end_value}&"
-            f"{data}"
+            if "packets/SID" not in self.__webpoda_url
+            else self.__webpoda_url
         )
+        url_base = url_base.rstrip("/")
+        url = f"{url_base}/{packet}.{extension}?{time_var}%3E={start_value}&{time_var}%3C{end_value}&{data}"
         logger.debug(f"Downloading from: {url}")
 
         try:


### PR DESCRIPTION
Now the service ID comes from config in the URL base from ENV var MAG_FETCH_BINARY_API_URL_BASE which is now part of the platform deploy