### PR TITLE
fix: Resolve files by name & layers versioned together

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 requires-python = ">=3.11,<3.15"
 name = "imap-mag"
-version = "5.0.0"
+version = "5.1.0"
 description = "Process IMAP data"
 authors = [
   {name = "alastairtree"},

--- a/src/imap_mag/cli/apply.py
+++ b/src/imap_mag/cli/apply.py
@@ -11,7 +11,7 @@ from imap_mag.cli.cliUtils import (
     initialiseLoggingForCommand,
 )
 from imap_mag.config import AppSettings, SaveMode
-from imap_mag.io import DatastoreFileFinder, DatastoreFileManager
+from imap_mag.io import DatastoreFileManager, FileFinder
 from imap_mag.io.file import (
     AncillaryPathHandler,
     CalibrationLayerPathHandler,
@@ -36,7 +36,7 @@ class FileType(Enum):
 
 # TODO: REFACTOR - moving files to a work folder could be simplified/generalized?
 def _prepare_layers_for_application(
-    layers: list[str], datastore_finder: DatastoreFileFinder, appSettings: AppSettings
+    layers: list[str], datastore_finder: FileFinder, appSettings: AppSettings
 ) -> list[Path]:
     """
     Prepare the calibration layers for application by fetching the versioned files.
@@ -53,7 +53,7 @@ def _prepare_layers_for_application(
                 f"Could not parse metadata from calibration metadata file: {layer}"
             )
 
-        versioned_layer_file: Path = datastore_finder.find_matching_file(
+        versioned_layer_file: Path = datastore_finder.find_by_handler(
             path_handler=cal_handler,
             throw_if_not_found=True,
         )
@@ -84,12 +84,12 @@ def _prepare_rotation_layer_for_application(rotation, appSettings):
     Prepare the rotation layer for application by fetching the versioned file.
     """
     if rotation:
-        datastore_finder = DatastoreFileFinder(appSettings.data_store)
+        datastore_finder = FileFinder(appSettings.data_store)
         rotation_handler = AncillaryPathHandler.from_filename(rotation)
         if not rotation_handler:
             logger.error(f"Could not parse metadata from rotation file: {rotation}")
             raise ValueError(f"Could not parse metadata from rotation file: {rotation}")
-        versioned_rotation_file = datastore_finder.find_matching_file(
+        versioned_rotation_file = datastore_finder.find_by_handler(
             path_handler=rotation_handler,
             throw_if_not_found=True,
         )
@@ -234,9 +234,11 @@ def _apply_for_date(
         )
 
     # Resolve layer patterns to actual filenames
-    datastore_finder = DatastoreFileFinder(app_settings.data_store)
+    datastore_finder = FileFinder(app_settings.data_store, app_settings.work_folder)
     resolved_layers = (
-        datastore_finder.find_layers(layers, date, mode, throw_if_not_found=True)
+        datastore_finder.find_layers_by_date_and_patterns(
+            layers, date, mode, throw_if_not_found=True
+        )
         if layers
         else []  # ensure we throw if a layer is passed in but not found
     )
@@ -248,9 +250,10 @@ def _apply_for_date(
                 "Either an input science file or a mode (norm/burst) must be provided "
                 "so the science file can be discovered."
             )
-        input = datastore_finder.find_science_file(date, mode, MAGSensor.OBS)
+        input = datastore_finder.find_latests_science_by_date(date, mode, MAGSensor.OBS)
 
-    original_input_handler = SciencePathHandler.from_filename(input)
+    # Parse metadata from the filename regardless of where the file lives
+    original_input_handler = SciencePathHandler.from_filename(Path(input).name)
 
     if not original_input_handler:
         logger.error(f"Could not parse metadata from input file: {input}")
@@ -264,12 +267,18 @@ def _apply_for_date(
             "At least one of calibration layers or rotation file must be provided."
         )
 
-    versioned_science_file = datastore_finder.find_matching_file(
-        path_handler=original_input_handler,
-        throw_if_not_found=True,
+    versioned_science_file = datastore_finder.find_by_name_or_path(
+        input, throw_if_not_found=True
     )
 
     logger.info(f"Applying layers to input file {versioned_science_file}")
+
+    if (
+        spice_metakernel is not None
+    ):  # not generating a metakernel, but one is provided, so need to resolve the path
+        spice_metakernel = datastore_finder.find_by_name_or_path(
+            spice_metakernel, throw_if_not_found=True
+        )
 
     workScienceFile: Path = fetch_file_for_work(
         versioned_science_file, app_settings.work_folder, throw_if_not_found=True

--- a/src/imap_mag/cli/apply.py
+++ b/src/imap_mag/cli/apply.py
@@ -250,7 +250,7 @@ def _apply_for_date(
                 "Either an input science file or a mode (norm/burst) must be provided "
                 "so the science file can be discovered."
             )
-        input = datastore_finder.find_latests_science_by_date(date, mode, MAGSensor.OBS)
+        input = datastore_finder.find_latest_science_by_date(date, mode, MAGSensor.OBS)
 
     # Parse metadata from the filename regardless of where the file lives
     original_input_handler = SciencePathHandler.from_filename(Path(input).name)

--- a/src/imap_mag/cli/calibrate.py
+++ b/src/imap_mag/cli/calibrate.py
@@ -8,10 +8,12 @@ import typer
 from imap_mag.cli import apply
 from imap_mag.cli.cliUtils import initialiseLoggingForCommand
 from imap_mag.config import AppSettings, CalibrationConfig, GradiometryConfig, SaveMode
-from imap_mag.io import DatastoreFileFinder, DatastoreFileManager
+from imap_mag.db.Database import Database
+from imap_mag.io import DatastoreFileManager, FileFinder
 from imap_mag.io.file import CalibrationLayerPathHandler
 from imap_mag.util import ScienceMode
 from mag_toolkit.calibration import (
+    CalibrationJob,
     CalibrationJobParameters,
     CalibrationMethod,
     EmptyCalibrationJob,
@@ -19,6 +21,7 @@ from mag_toolkit.calibration import (
     Sensor,
     SetQualityAndNaNCalibrationJob,
 )
+from mag_toolkit.calibration.CalibrationLayer import CalibrationLayer
 
 app = typer.Typer()
 
@@ -137,6 +140,11 @@ def _calibrate_for_date(
     initialiseLoggingForCommand(
         work_folder
     )  # DO NOT log anything before this point (it won't be captured in the log file)
+    datastore_finder = FileFinder(
+        app_settings.data_store,
+        work_folder,
+        database=Database() if Database.get_environment_url() else None,
+    )
 
     if configuration is None:
         calibration_configuration = CalibrationConfig()
@@ -149,7 +157,7 @@ def _calibrate_for_date(
     calibration_job_parameters = CalibrationJobParameters(
         date=start_date, mode=mode, sensor=sensor
     )
-
+    calibrator: CalibrationJob
     match method:
         case CalibrationMethod.NOOP:
             calibrator = EmptyCalibrationJob(calibration_job_parameters, work_folder)
@@ -159,12 +167,10 @@ def _calibrate_for_date(
             )
         case CalibrationMethod.SET_QUALITY_AND_NAN:
             calibrator = SetQualityAndNaNCalibrationJob(
-                calibration_job_parameters, work_folder
+                calibration_job_parameters, work_folder, datastore_finder
             )
         case _:
             raise ValueError("Calibration method is not implemented")
-
-    datastore_finder = DatastoreFileFinder(app_settings.data_store)
 
     calibrator.setup_calibration_files(datastore_finder)
     calibrator.setup_datastore(app_settings.data_store)
@@ -172,13 +178,22 @@ def _calibrate_for_date(
     calibration_handler = CalibrationLayerPathHandler(
         descriptor=f"{method.short_name}-{mode.value}", content_date=start_date
     )
-    calibration_handler = calibrator.get_next_viable_version_layer(
-        datastore_finder, calibration_handler
-    )
+    calibrator.set_layer_to_next_viable_version(datastore_finder, calibration_handler)
 
     metadata_path, data_path = calibrator.run_calibration(
         calibration_handler, calibration_configuration
     )
+
+    # verify that file and datafile are valid
+    layer = CalibrationLayer.from_file(metadata_path, load_contents=False)
+    if not layer.metadata.data_filename or not data_path.exists():
+        raise FileNotFoundError(
+            f"Calibration layer file at {metadata_path!s} has data file {layer.metadata.data_filename!s} that was not found"
+        )
+    if data_path.name != layer.metadata.data_filename.name:
+        raise ValueError(
+            f"Calibration layer metadata file {metadata_path!s} specifies data file {layer.metadata.data_filename!s} but actual data file is {data_path!s}."
+        )
 
     outputManager = DatastoreFileManager.CreateByMode(
         app_settings, use_database=save_mode == SaveMode.LocalAndDatabase
@@ -187,8 +202,14 @@ def _calibrate_for_date(
     (output_calibration_path, _) = outputManager.add_file(
         metadata_path, path_handler=calibration_handler
     )
-    outputManager.add_file(
+
+    result_data_file, _ = outputManager.add_file(
         data_path, path_handler=calibration_handler.get_equivalent_data_handler()
     )
+
+    if result_data_file.name != layer.metadata.data_filename.name:
+        raise ValueError(
+            f"Output data file {result_data_file!s} does not match expected data filename {layer.metadata.data_filename!s} specified in calibration layer metadata."
+        )
 
     return output_calibration_path

--- a/src/imap_mag/cli/cliUtils.py
+++ b/src/imap_mag/cli/cliUtils.py
@@ -113,8 +113,11 @@ def fetch_file_for_work(
         f"{files[0].absolute().as_posix()}"
     )
 
-    # copy the file to work_folder
+    # copy the file to work_folder (skip if it is already there)
     work_file = Path(work_folder, files[0].name)
+    if files[0].resolve() == work_file.resolve():
+        logger.debug(f"File {files[0]} is already in work folder, no copy needed.")
+        return work_file
     logger.debug(f"Copying {files[0]} to {work_file}")
     work_file = Path(shutil.copy2(files[0], work_folder))
 

--- a/src/imap_mag/cli/fetch/ialirt.py
+++ b/src/imap_mag/cli/fetch/ialirt.py
@@ -9,7 +9,7 @@ from imap_mag.cli.cliUtils import initialiseLoggingForCommand
 from imap_mag.client.IALiRTApiClient import IALiRTApiClient
 from imap_mag.config import AppSettings, FetchMode
 from imap_mag.download.FetchIALiRT import FetchIALiRT
-from imap_mag.io import DatastoreFileFinder, DatastoreFileManager
+from imap_mag.io import DatastoreFileManager, FileFinder
 from imap_mag.io.file import IALiRTHKPathHandler, IALiRTPathHandler
 from imap_mag.io.file.IFilePathHandler import IFilePathHandler
 
@@ -23,7 +23,7 @@ def _create_fetch_ialirt(app_settings: AppSettings) -> FetchIALiRT:
         app_settings.fetch_ialirt.api.auth_code,
         app_settings.fetch_ialirt.api.url_base,
     )
-    datastore_finder = DatastoreFileFinder(app_settings.data_store)
+    datastore_finder = FileFinder(app_settings.data_store)
     work_folder = app_settings.setup_work_folder_for_command(app_settings.fetch_ialirt)
 
     initialiseLoggingForCommand(

--- a/src/imap_mag/cli/ialirtUtils.py
+++ b/src/imap_mag/cli/ialirtUtils.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pandas as pd
 
 from imap_mag.cli.cliUtils import fetch_file_for_work
-from imap_mag.io import DatastoreFileFinder
+from imap_mag.io import FileFinder
 from imap_mag.io.file import IALiRTHKPathHandler, IALiRTPathHandler
 from imap_mag.io.file.IFilePathHandler import IFilePathHandler
 from imap_mag.util import DatetimeProvider
@@ -62,7 +62,7 @@ def _fetch_files_for_work(
     path_handler_factory,
     label: str,
 ) -> list[Path]:
-    datastore_finder = DatastoreFileFinder(data_store)
+    datastore_finder = FileFinder(data_store)
 
     if (
         (start_date is None)
@@ -89,7 +89,7 @@ def _fetch_files_for_work(
         files = []
 
         for handler in path_handlers:
-            f = datastore_finder.find_matching_file(handler, throw_if_not_found=False)
+            f = datastore_finder.find_by_handler(handler, throw_if_not_found=False)
             if f is not None:
                 files.append(f)
 

--- a/src/imap_mag/cli/process.py
+++ b/src/imap_mag/cli/process.py
@@ -7,8 +7,8 @@ import typer
 from imap_mag.cli.cliUtils import initialiseLoggingForCommand
 from imap_mag.config import AppSettings, SaveMode
 from imap_mag.io import (
-    DatastoreFileFinder,
     DatastoreFileManager,
+    FileFinder,
     FilePathHandlerSelector,
 )
 from imap_mag.io.file import IFilePathHandler
@@ -45,7 +45,7 @@ def process(
 
     logger.info(f"Processing {len(files)} files:\n{', '.join(str(f) for f in files)}")
 
-    datastore_finder = DatastoreFileFinder(app_settings.data_store)
+    datastore_finder = FileFinder(app_settings.data_store)
     datastore_manager = DatastoreFileManager.CreateByMode(
         app_settings,
         use_database=(save_mode == SaveMode.LocalAndDatabase),
@@ -66,7 +66,7 @@ def process(
                 )
                 continue
 
-            file = datastore_finder.find_matching_file(
+            file = datastore_finder.find_by_handler(
                 path_handler, throw_if_not_found=True
             )
 

--- a/src/imap_mag/cli/publish.py
+++ b/src/imap_mag/cli/publish.py
@@ -7,8 +7,7 @@ import typer
 from imap_mag.cli.cliUtils import initialiseLoggingForCommand
 from imap_mag.client.SDCDataAccess import SDCDataAccess, SDCUploadError
 from imap_mag.config import AppSettings
-from imap_mag.io import DatastoreFileFinder, FilePathHandlerSelector
-from imap_mag.io.file import IFilePathHandler
+from imap_mag.io.FileFinder import FileFinder
 
 logger = logging.getLogger(__name__)
 
@@ -38,18 +37,12 @@ def publish(
 
     logger.info(f"Publishing {len(files)} files: {', '.join(str(f) for f in files)}")
 
+    datastore_finder = FileFinder(app_settings.data_store, work_folder)
+
     resolved_files: list[Path] = []
-    datastore_finder = DatastoreFileFinder(app_settings.data_store)
-
     for file in files:
-        path_handler: IFilePathHandler = FilePathHandlerSelector.find_by_path(
-            file, throw_if_not_found=True
-        )
-
-        resolved_file = datastore_finder.find_matching_file(
-            path_handler, throw_if_not_found=True
-        )
-        resolved_files.append(resolved_file)
+        resolved = datastore_finder.find_by_name_or_path(file, throw_if_not_found=True)
+        resolved_files.append(resolved)
 
     logger.info(
         f"Found {len(resolved_files)} files for publish: {', '.join(str(f) for f in resolved_files)}"
@@ -57,7 +50,6 @@ def publish(
 
     # Publish file to SDC.
     failed: int = 0
-
     data_access = SDCDataAccess(
         auth_code=app_settings.publish.api.auth_code,
         data_dir=work_folder,

--- a/src/imap_mag/db/Database.py
+++ b/src/imap_mag/db/Database.py
@@ -17,7 +17,7 @@ class Database:
     __active_session: Session | None
 
     def __init__(self, db_url=None):
-        env_url = os.getenv("SQLALCHEMY_URL")
+        env_url = self.get_environment_url()
         if db_url is None and env_url is not None:
             db_url = env_url
 
@@ -28,6 +28,10 @@ class Database:
 
         self.engine = create_engine(db_url, pool_pre_ping=True)
         self.session = sessionmaker(bind=self.engine)
+
+    @classmethod
+    def get_environment_url(cls) -> str | None:
+        return os.getenv("SQLALCHEMY_URL")
 
     @staticmethod
     def __session_manager(

--- a/src/imap_mag/download/FetchIALiRT.py
+++ b/src/imap_mag/download/FetchIALiRT.py
@@ -8,7 +8,7 @@ import pandas as pd
 import yaml
 
 from imap_mag.client.IALiRTApiClient import IALiRTApiClient
-from imap_mag.io import DatastoreFileFinder
+from imap_mag.io import FileFinder
 from imap_mag.io.file import IALiRTHKPathHandler, IALiRTPathHandler
 from imap_mag.io.file.IFilePathHandler import IFilePathHandler
 from imap_mag.process import get_packet_definition_folder
@@ -27,7 +27,7 @@ class FetchIALiRT:
         self,
         data_access: IALiRTApiClient,
         work_folder: Path,
-        datastore_finder: DatastoreFileFinder,
+        datastore_finder: FileFinder,
         packet_definition: Path,
     ) -> None:
         """Initialize I-ALiRT interface."""
@@ -138,7 +138,7 @@ class FetchIALiRT:
                 path_handler = path_handler_factory(max_daily_date)
 
                 # Find file in datastore
-                file_path: Path | None = self.__datastore_finder.find_matching_file(
+                file_path: Path | None = self.__datastore_finder.find_by_handler(
                     path_handler, throw_if_not_found=False
                 )
 

--- a/src/imap_mag/io/DBIndexedDatastoreFileManager.py
+++ b/src/imap_mag/io/DBIndexedDatastoreFileManager.py
@@ -44,11 +44,10 @@ class DBIndexedDatastoreFileManager(IDatastoreFileManager):
 
     def add_file(self, original_file: Path, path_handler: T) -> tuple[Path, T]:
         # Check if the version needs to be increased
-        original_hash: str = generate_hash(original_file)
 
         skip_database_insertion: bool = self.__get_next_available_version(
+            original_file,
             path_handler,
-            original_hash=original_hash,
         )
 
         # Add file locally
@@ -58,7 +57,7 @@ class DBIndexedDatastoreFileManager(IDatastoreFileManager):
 
         if not (
             destination_file.exists()
-            and (generate_hash(destination_file) == original_hash)
+            and (generate_hash(destination_file) == generate_hash(original_file))
         ):
             logger.error(
                 f"File {destination_file} does not exist or is not the same as original {original_file}."
@@ -89,7 +88,7 @@ class DBIndexedDatastoreFileManager(IDatastoreFileManager):
                 new_file = File.from_file(
                     file=destination_file,
                     version=version,
-                    hash=original_hash,
+                    hash=generate_hash(destination_file),
                     content_date=path_handler.get_content_date_for_indexing(),
                     settings=self.__settings,
                 )
@@ -196,8 +195,8 @@ class DBIndexedDatastoreFileManager(IDatastoreFileManager):
 
     def __get_next_available_version(
         self,
+        original_file: Path,
         path_handler: IFilePathHandler,
-        original_hash: str,
     ) -> bool:
         """Find a viable version for a file."""
 
@@ -212,6 +211,7 @@ class DBIndexedDatastoreFileManager(IDatastoreFileManager):
         database_files: list[File] = self.__get_matching_database_files(path_handler)
 
         # Find the file whose hash matches the original file
+        original_hash: str = generate_hash(original_file)
         matching_files: list[File] = [
             f for f in database_files if f.hash == original_hash
         ]

--- a/src/imap_mag/io/DatastoreFileManager.py
+++ b/src/imap_mag/io/DatastoreFileManager.py
@@ -37,10 +37,9 @@ class DatastoreFileManager(IDatastoreFileManager):
             logger.debug(f"Output location does not exist. Creating {self.location}.")
             self.location.mkdir(parents=True, exist_ok=True)
 
-        original_hash = generate_hash(original_file)
         skip_file_copy: bool = self.__get_next_available_version(
+            original_file,
             path_handler,
-            original_hash=original_hash,
         )
         destination_file: Path = path_handler.get_full_path(self.location)
 
@@ -70,30 +69,28 @@ class DatastoreFileManager(IDatastoreFileManager):
 
     def __get_next_available_version(
         self,
+        original_file: Path,
         path_handler: IFilePathHandler,
-        original_hash: str,
     ) -> bool:
         """Find a viable version for a file."""
+
+        destination_file: Path = path_handler.get_full_path(self.location)
 
         if not path_handler.supports_sequencing():
             logger.debug(
                 "Versioning not supported. File may be overwritten if it already exists and is different."
             )
 
-            destination_file: Path = path_handler.get_full_path(self.location)
-
             return (
-                original_hash == generate_hash(destination_file)
+                generate_hash(original_file) == generate_hash(destination_file)
                 if destination_file.exists()
                 else False
             )
         else:
             assert isinstance(path_handler, SequenceablePathHandler)
 
-        destination_file = path_handler.get_full_path(self.location)
-
         while destination_file.exists():
-            if generate_hash(destination_file) == original_hash:
+            if generate_hash(destination_file) == generate_hash(original_file):
                 return True
 
             logger.debug(

--- a/src/imap_mag/io/FileFinder.py
+++ b/src/imap_mag/io/FileFinder.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Literal, overload
 
+from imap_mag.db.Database import Database
 from imap_mag.io.file import (
     CalibrationLayerPathHandler,
     IFilePathHandler,
@@ -13,20 +14,30 @@ from imap_mag.io.file import (
     SequenceablePathHandler,
     VersionedPathHandler,
 )
+from imap_mag.io.FilePathHandlerSelector import FilePathHandlerSelector
 from imap_mag.util import MAGSensor, ScienceMode
 
 logger = logging.getLogger(__name__)
 
 
-class DatastoreFileFinder:
+class FileFinder:
     """Find files in the datastore."""
 
-    location: Path
+    _data_store: Path
+    _work_folder: Path | None
+    _database: Database | None
 
-    def __init__(self, location: Path) -> None:
-        self.location = location
+    def __init__(
+        self,
+        data_store: Path,
+        work_folder: Path | None = None,
+        database: Database | None = None,
+    ) -> None:
+        self._data_store = data_store
+        self._work_folder = work_folder
+        self._database = database
 
-    def find_all_file_parts(
+    def find_parts_by_handler(
         self,
         path_handler: PartitionedPathHandler,
         throw_if_not_found: bool = False,
@@ -40,7 +51,7 @@ class DatastoreFileFinder:
         return [Path(file) for file, _ in all_matching_files]
 
     @overload
-    def find_latest_version(
+    def find_latest_version_by_handler(
         self,
         path_handler: VersionedPathHandler,
         throw_if_not_found: Literal[True] = True,
@@ -48,14 +59,14 @@ class DatastoreFileFinder:
         pass
 
     @overload
-    def find_latest_version(
+    def find_latest_version_by_handler(
         self,
         path_handler: VersionedPathHandler,
         throw_if_not_found: Literal[False] = False,
     ) -> Path | None:
         pass
 
-    def find_latest_version(
+    def find_latest_version_by_handler(
         self,
         path_handler: VersionedPathHandler,
         throw_if_not_found: bool = True,
@@ -73,7 +84,7 @@ class DatastoreFileFinder:
         return Path(filename_with_sequence)
 
     @overload
-    def find_matching_file(
+    def find_by_handler(
         self,
         path_handler: IFilePathHandler,
         throw_if_not_found: Literal[True] = True,
@@ -81,20 +92,20 @@ class DatastoreFileFinder:
         pass
 
     @overload
-    def find_matching_file(
+    def find_by_handler(
         self,
         path_handler: IFilePathHandler,
         throw_if_not_found: Literal[False] = False,
     ) -> Path | None:
         pass
 
-    def find_matching_file(
+    def find_by_handler(
         self,
         path_handler: IFilePathHandler,
         throw_if_not_found: bool = True,
     ) -> Path | None:
         matching_file = (
-            self.location
+            self._data_store
             / path_handler.get_folder_structure()
             / path_handler.get_filename()
         )
@@ -111,7 +122,7 @@ class DatastoreFileFinder:
         else:
             return None
 
-    def find_layers(
+    def find_layers_by_date_and_patterns(
         self,
         layers: list[str],
         date: datetime,
@@ -195,26 +206,25 @@ class DatastoreFileFinder:
                 best[key] = (name, handler.version)
         return [name for name, _ in best.values()]
 
-    def find_science_file(
-        self, date: datetime, mode: ScienceMode, sensor: MAGSensor
+    def find_latests_science_by_date(
+        self,
+        date: datetime,
+        mode: ScienceMode,
+        sensor: MAGSensor,
+        levels_to_search=["l1c", "l1b"],
     ) -> str:
         """Find the highest version science file for a given date and mode.
-
-        For burst mode, only L1B files are used.
-        For normal mode, L1C files are preferred; falls back to L1B if no L1C exists.
-
         Returns the filename of the highest version match.
         """
         date_str = date.strftime("%Y%m%d")
-        science_dir = self.location / "science" / "mag"
+        science_dir = self._data_store / "science" / "mag"
 
         if not science_dir.exists():
             raise FileNotFoundError(f"Science directory {science_dir} does not exist")
 
         if mode == ScienceMode.Burst:
-            levels_to_search = ["l1b"]
-        else:
-            levels_to_search = ["l1c", "l1b"]
+            # Remove l1c from levels to search for burst mode as no BM in L1C
+            levels_to_search = [level for level in levels_to_search if level != "l1c"]
 
         for level in levels_to_search:
             date_dir = science_dir / level / date.strftime("%Y") / date.strftime("%m")
@@ -253,7 +263,7 @@ class DatastoreFileFinder:
         filename_only: bool = False,
     ) -> list[tuple[str, int]]:
         pattern = path_handler.get_unsequenced_pattern()
-        folder = self.location / path_handler.get_folder_structure()
+        folder = self._data_store / path_handler.get_folder_structure()
         sequence_name = path_handler.get_sequence_variable_name()
 
         all_matching_files = [
@@ -292,3 +302,105 @@ class DatastoreFileFinder:
             ]
 
         return all_matching_files
+
+    @overload
+    def find_by_name_or_path(
+        self, file_name_or_path: "str | Path", throw_if_not_found: Literal[True] = True
+    ) -> "Path":
+        pass
+
+    @overload
+    def find_by_name_or_path(
+        self,
+        file_name_or_path: "str | Path",
+        throw_if_not_found: Literal[False] = False,
+    ) -> "Path | None":
+        pass
+
+    def find_by_name_or_path(
+        self, file_name_or_path: "str | Path", throw_if_not_found: bool = False
+    ) -> "Path | None":
+        path = (
+            Path(file_name_or_path)
+            if isinstance(file_name_or_path, str)
+            else file_name_or_path
+        )
+
+        # path already exists → return immediately
+        if path.exists():
+            logger.debug("Resolved '%s' via existing path.", file_name_or_path)
+            return path
+
+        # Relative path from data_store
+        candidate = self._data_store / path
+        if candidate.exists():
+            logger.debug(
+                "Resolved '%s' relative to data_store: %s", file_name_or_path, candidate
+            )
+            return candidate
+
+        # Relative path from _work_folder
+        if self._work_folder is not None:
+            candidate = self._work_folder / path
+            if candidate.exists():
+                logger.debug(
+                    "Resolved '%s' relative to work_folder: %s",
+                    file_name_or_path,
+                    candidate,
+                )
+                return candidate
+
+        # Steps that apply only to bare filenames (no directory component).
+        if path.parent == Path("."):
+            filename = path.name
+
+            # try using the path handlers
+            handler = FilePathHandlerSelector.find_by_path(
+                path, throw_if_not_found=False
+            )
+            if handler is not None:
+                candidate = (
+                    self._data_store
+                    / handler.get_folder_structure()
+                    / handler.get_filename()
+                )
+                if candidate.exists():
+                    logger.debug(
+                        "Resolved '%s' via path handler in data_store: %s",
+                        file_name_or_path,
+                        candidate,
+                    )
+                    return candidate
+
+            # try using the database (if available)
+            if self._database is not None:
+                try:
+                    files = self._database.get_files(name=filename, deletion_date=None)
+                    if files:
+                        db_path = self._data_store / files[0].path
+                        if db_path.exists():
+                            logger.debug(
+                                "Resolved '%s' via database record: %s",
+                                file_name_or_path,
+                                db_path,
+                            )
+                            return db_path
+                except Exception:
+                    logger.error(
+                        "Database lookup failed for '%s'.",
+                        file_name_or_path,
+                        exc_info=True,
+                    )
+                    raise
+
+        if throw_if_not_found:
+            raise FileNotFoundError(
+                f"File not found: '{file_name_or_path}'. "
+                f"Searched: local path, "
+                f"data_store ({self._data_store}), "
+                f"CWD ({Path.cwd()}), "
+                f"work_folder ({self._work_folder}), "
+                f"file path handlers, and database."
+            )
+        else:
+            return None

--- a/src/imap_mag/io/FileFinder.py
+++ b/src/imap_mag/io/FileFinder.py
@@ -206,7 +206,7 @@ class FileFinder:
                 best[key] = (name, handler.version)
         return [name for name, _ in best.values()]
 
-    def find_latests_science_by_date(
+    def find_latest_science_by_date(
         self,
         date: datetime,
         mode: ScienceMode,
@@ -331,14 +331,6 @@ class FileFinder:
             logger.debug("Resolved '%s' via existing path.", file_name_or_path)
             return path
 
-        # Relative path from data_store
-        candidate = self._data_store / path
-        if candidate.exists():
-            logger.debug(
-                "Resolved '%s' relative to data_store: %s", file_name_or_path, candidate
-            )
-            return candidate
-
         # Relative path from _work_folder
         if self._work_folder is not None:
             candidate = self._work_folder / path
@@ -349,6 +341,14 @@ class FileFinder:
                     candidate,
                 )
                 return candidate
+
+        # Relative path from data_store
+        candidate = self._data_store / path
+        if candidate.exists():
+            logger.debug(
+                "Resolved '%s' relative to data_store: %s", file_name_or_path, candidate
+            )
+            return candidate
 
         # Steps that apply only to bare filenames (no directory component).
         if path.parent == Path("."):

--- a/src/imap_mag/io/__init__.py
+++ b/src/imap_mag/io/__init__.py
@@ -1,6 +1,6 @@
-from imap_mag.io.DatastoreFileFinder import DatastoreFileFinder
 from imap_mag.io.DatastoreFileManager import DatastoreFileManager, generate_hash
 from imap_mag.io.DBIndexedDatastoreFileManager import DBIndexedDatastoreFileManager
+from imap_mag.io.FileFinder import FileFinder
 from imap_mag.io.FilePathHandlerSelector import (
     FilePathHandlerSelector,
     NoProviderFoundError,
@@ -9,8 +9,8 @@ from imap_mag.io.IDatastoreFileManager import IDatastoreFileManager
 
 __all__ = [
     "DBIndexedDatastoreFileManager",
-    "DatastoreFileFinder",
     "DatastoreFileManager",
+    "FileFinder",
     "FilePathHandlerSelector",
     "IDatastoreFileManager",
     "NoProviderFoundError",

--- a/src/imap_mag/io/file/CalibrationLayerPathHandler.py
+++ b/src/imap_mag/io/file/CalibrationLayerPathHandler.py
@@ -92,3 +92,14 @@ class CalibrationLayerPathHandler(VersionedPathHandler):
                 version=int(match["version"]),
                 extension=match["ext"],
             )
+
+    def register_callback_on_resequencing(self, callback) -> None:
+        self._version_change_callback = callback
+
+    def increase_sequence(self) -> None:
+        super().increase_sequence()
+        if hasattr(self, "_version_change_callback"):
+            self._version_change_callback(self)
+        logger.debug(
+            f"Increased version to {self.version} for file {self.get_filename()}."
+        )

--- a/src/imap_mag/process/HKProcessor.py
+++ b/src/imap_mag/process/HKProcessor.py
@@ -12,7 +12,7 @@ import xarray as xr
 from rich.progress import track
 from space_packet_parser.exceptions import UnrecognizedPacketTypeError
 
-from imap_mag.io import DatastoreFileFinder
+from imap_mag.io import FileFinder
 from imap_mag.io.file import HKBinaryPathHandler, HKDecodedPathHandler, IFilePathHandler
 from imap_mag.process.FileProcessor import FileProcessor
 from imap_mag.process.get_packet_definition_folder import get_packet_definition_folder
@@ -31,9 +31,7 @@ logger = logging.getLogger(__name__)
 class HKProcessor(FileProcessor):
     __xtcePacketDefinitionFolder: Path
 
-    def __init__(
-        self, work_folder: Path, datastore_finder: DatastoreFileFinder
-    ) -> None:
+    def __init__(self, work_folder: Path, datastore_finder: FileFinder) -> None:
         self.__work_folder = work_folder
         self.__datastore_finder = datastore_finder
 
@@ -199,7 +197,7 @@ class HKProcessor(FileProcessor):
                     extension="pkts",
                 )
 
-                day_files: list[Path] = self.__datastore_finder.find_all_file_parts(
+                day_files: list[Path] = self.__datastore_finder.find_parts_by_handler(
                     l0_path_handler, throw_if_not_found=False
                 )
 

--- a/src/imap_mag/process/dispatch.py
+++ b/src/imap_mag/process/dispatch.py
@@ -1,7 +1,7 @@
 import logging
 from pathlib import Path
 
-from imap_mag.io import DatastoreFileFinder
+from imap_mag.io import FileFinder
 from imap_mag.process.FileProcessor import FileProcessor
 from imap_mag.process.HKProcessor import HKProcessor
 
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 
 def dispatch(
-    file: Path | list[Path], work_folder: Path, datastore_finder: DatastoreFileFinder
+    file: Path | list[Path], work_folder: Path, datastore_finder: FileFinder
 ) -> FileProcessor:
     """Dispatch a file or a list of files to the appropriate processor."""
 

--- a/src/mag_toolkit/calibration/CalibrationApplicator.py
+++ b/src/mag_toolkit/calibration/CalibrationApplicator.py
@@ -161,12 +161,12 @@ class CalibrationApplicator:
         )
 
         # need to get the spice furnished as the l2 step does time truncation needed clock kernels and rotations
-        path_to_mk = (
-            generate_spice_metakernel(
-                start_time=day_to_process + timedelta(hours=-12),
+        if spice_metakernel is None:
+            spice_metakernel = generate_spice_metakernel(
+                start_time=day_to_process + timedelta(hours=-1),
                 end_time=day_to_process
                 + timedelta(
-                    days=1, hours=12
+                    days=1, hours=1
                 ),  # ensure we have plenty of spice coverage around it
                 file_types=[
                     "leapseconds",
@@ -180,13 +180,14 @@ class CalibrationApplicator:
                     "ephemeris_reconstructed",
                 ],
                 verify=False,
-            )
-            if spice_metakernel is None
-            else Path(spice_metakernel)
-        )
-        resolved_mk_path: str = str(path_to_mk.resolve())  # type: ignore
+            )  # type: ignore
 
-        if not Path(resolved_mk_path).exists():
+        if spice_metakernel is None:
+            raise ValueError("Failed to generate spice metakernel for L2 generation")
+
+        resolved_mk_path = spice_metakernel.resolve()
+
+        if not resolved_mk_path.exists():
             raise ValueError(
                 f"Resolved spice metakernel path does not exist: {resolved_mk_path}"
             )
@@ -197,7 +198,7 @@ class CalibrationApplicator:
         try:
             os.chdir(self.app_settings.data_store)
             spiceypy.kclear()
-            spiceypy.furnsh(resolved_mk_path)
+            spiceypy.furnsh(str(resolved_mk_path))
             os.chdir(original_cwd)
             logger.info("Kernels furnished. Loading data ready for L2 file generation")
             science_data = cdf_to_xarray(str(dataFile), to_datetime=False)
@@ -224,9 +225,6 @@ class CalibrationApplicator:
         finally:
             os.chdir(original_cwd)
             spiceypy.kclear()
-            os.remove(
-                resolved_mk_path
-            ) if spice_metakernel is None else None  # clean up the generated metakernel
             del science_data
             del created_offsets_data
 

--- a/src/mag_toolkit/calibration/CalibrationLayer.py
+++ b/src/mag_toolkit/calibration/CalibrationLayer.py
@@ -264,6 +264,9 @@ class CalibrationLayer(Layer):
     def _from_csv(cls, path: Path):
         df = cls._values_from_csv(path)
 
+        if df.empty:
+            raise ValueError("CSV file is empty or does not contain valid data")
+
         validity = Validity(
             start=df[CONSTANTS.CSV_VARS.EPOCH].iloc[0],
             end=df[CONSTANTS.CSV_VARS.EPOCH].iloc[-1],

--- a/src/mag_toolkit/calibration/calibrators/CalibrationJob.py
+++ b/src/mag_toolkit/calibration/calibrators/CalibrationJob.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from imap_mag.cli.cliUtils import fetch_file_for_work
 from imap_mag.config.CalibrationConfig import CalibrationConfig
-from imap_mag.io import DatastoreFileFinder
+from imap_mag.io import FileFinder
 from imap_mag.io.file import CalibrationLayerPathHandler
 from mag_toolkit.calibration.CalibrationJobParameters import CalibrationJobParameters
 
@@ -26,13 +26,13 @@ class CalibrationJob(ABC):
 
     def setup_calibration_files(
         self,
-        datastore_finder: DatastoreFileFinder,
+        datastore_finder: FileFinder,
     ):
         path_handlers = self._get_path_handlers(self.calibration_job_parameters)
 
         for key in path_handlers:
             path_handler = path_handlers[key]
-            input_file = datastore_finder.find_latest_version(
+            input_file = datastore_finder.find_latest_version_by_handler(
                 path_handler, throw_if_not_found=True
             )
             work_file = fetch_file_for_work(
@@ -61,30 +61,40 @@ class CalibrationJob(ABC):
         :param sensor: The sensor type.
         :return: A dictionary of path handlers."""
 
-    def get_next_viable_version_layer(
+    def set_layer_to_next_viable_version(
         self,
-        datastore_finder: DatastoreFileFinder,
+        datastore_finder: FileFinder,
         layer_handler: CalibrationLayerPathHandler,
-    ) -> CalibrationLayerPathHandler:
+    ):
         """
         Get the next viable version for a calibration layer.
+
+        Checks both the JSON metadata file and the CSV data file so that the pair
+        is always versioned together — whichever file has the higher existing version
+        determines the base for the next version number.
+
         :return: Calibration layer handler for next viable version.
         """
 
-        latest_version_file: Path | None = datastore_finder.find_latest_version(
+        def _version_of(path: Path | None) -> int:
+            if path is None:
+                return 0
+            h = CalibrationLayerPathHandler.from_filename(path)
+            return h.version if h is not None else 0
+
+        latest_json_file: Path | None = datastore_finder.find_latest_version_by_handler(
             layer_handler, throw_if_not_found=False
         )
+        latest_csv_file: Path | None = datastore_finder.find_latest_version_by_handler(
+            layer_handler.get_equivalent_data_handler(), throw_if_not_found=False
+        )
 
-        if latest_version_file is None:
-            return layer_handler
-        else:
-            latest_version_handler: CalibrationLayerPathHandler | None = (
-                CalibrationLayerPathHandler.from_filename(latest_version_file)
-            )
-            assert latest_version_handler is not None
-
-            latest_version_handler.increase_sequence()
-            return latest_version_handler
+        max_existing_version = max(
+            _version_of(latest_json_file), _version_of(latest_csv_file)
+        )
+        if max_existing_version >= layer_handler.version:
+            layer_handler.version = max_existing_version
+            layer_handler.increase_sequence()
 
     def _check_environment_is_setup(self):
         if not self._check_for_required_files():

--- a/src/mag_toolkit/calibration/calibrators/SetQualityAndNaNCalibration.py
+++ b/src/mag_toolkit/calibration/calibrators/SetQualityAndNaNCalibration.py
@@ -7,6 +7,7 @@ import pandas as pd
 
 from imap_mag.config.CalibrationConfig import CalibrationConfig
 from imap_mag.io.file import CalibrationLayerPathHandler, SciencePathHandler
+from imap_mag.io.FileFinder import FileFinder
 from imap_mag.util import Level, ScienceMode
 from mag_toolkit.calibration.CalibrationDefinitions import (
     CONSTANTS,
@@ -29,11 +30,15 @@ class SetQualityAndNaNCalibrationJob(CalibrationJob):
     science_file_key = "science_file"
 
     def __init__(
-        self, calibration_job_parameters: CalibrationJobParameters, work_folder: Path
+        self,
+        calibration_job_parameters: CalibrationJobParameters,
+        work_folder: Path,
+        file_finder: FileFinder | None = None,
     ):
         super().__init__(calibration_job_parameters, work_folder)
         self.name = CalibrationMethod.SET_QUALITY_AND_NAN
         self.required_files[self.science_file_key] = None
+        self._finder = file_finder or FileFinder(work_folder, work_folder, None)
 
     def _get_path_handlers(self, calibration_job_parameters: CalibrationJobParameters):
         mode = calibration_job_parameters.mode
@@ -66,13 +71,9 @@ class SetQualityAndNaNCalibrationJob(CalibrationJob):
                 "with a csv_file path."
             )
 
-        csv_path = Path(config.set_quality_and_nan.csv_file)
-        # check if it is an absolute path, if not assume it's relative to the current working directory
-        if not csv_path.is_absolute() and self.data_store is not None:
-            csv_path = Path(self.data_store) / csv_path
-
-        if not csv_path.exists():
-            raise FileNotFoundError(f"SetQualityAndNaN CSV file not found: {csv_path}")
+        csv_path = self._finder.find_by_name_or_path(
+            config.set_quality_and_nan.csv_file, throw_if_not_found=True
+        )
 
         input_df = pd.read_csv(csv_path)
         input_df["start_date"] = pd.to_datetime(input_df["start_date"])
@@ -144,6 +145,14 @@ class SetQualityAndNaNCalibrationJob(CalibrationJob):
             raise FileNotFoundError(f"Calibration file {calfile} was not created.")
         if not datafile.exists():
             raise FileNotFoundError(f"Data file {datafile} was not created.")
+
+        def raise_if_resequenced():
+            raise ValueError(
+                f"Calibration file {calfile} and data file {datafile} may not be resequenced due to their interdependence. If you need to resequence, please delete these files and re-run the calibration."
+            )
+
+        cal_handler.register_callback_on_resequencing(raise_if_resequenced)
+        data_handler.register_callback_on_resequencing(raise_if_resequenced)
 
         return calfile, datafile
 

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -1,4 +1,5 @@
 import re
+import shutil
 from datetime import datetime
 from pathlib import Path
 
@@ -6,6 +7,8 @@ import numpy as np
 import pytest
 
 from imap_mag.cli.apply import apply
+from imap_mag.config import SaveMode
+from imap_mag.util import ScienceMode
 from tests.util.database import test_database  # noqa: F401
 from tests.util.miscellaneous import TEST_DATA, copy_test_file, open_cdf
 
@@ -294,3 +297,62 @@ def test_apply_writes_magnitudes_correctly(
             # Convert to list for comparison
             computed_magnitude = np.linalg.norm(correct_vec)
             assert mag == pytest.approx(computed_magnitude, rel=1e-6)
+
+
+def test_apply_uses_absolute_path_for_science_file(
+    tmp_path,
+    temp_datastore,
+    dynamic_work_folder,
+    spice_kernels,
+):
+    """apply() must use a science file given as an absolute path that lives
+    outside the datastore, rather than ignoring the path and looking in the
+    datastore by filename.
+
+    Bug: the old code extracted the filename, built a SciencePathHandler, then
+    called datastore_finder.find_matching_file() which always searched the
+    datastore.  An absolute path pointing to a copy of the file that was NOT
+    in the datastore would raise FileNotFoundError even though the file existed.
+    """
+    # Copy the science file to a location outside the datastore
+    science_in_datastore = (
+        temp_datastore
+        / "science/mag/l1c/2026/01/imap_mag_l1c_norm-mago_20260116_v001.cdf"
+    )
+    science_outside = tmp_path / "imap_mag_l1c_norm-mago_20260116_v001.cdf"
+    shutil.copy(science_in_datastore, science_outside)
+
+    # Remove the file from the datastore so the only copy is the external one
+    science_in_datastore.unlink()
+
+    # apply() must succeed using the absolute path directly
+    apply(
+        layers=["imap_mag_noop-norm-layer_20260116_v001.json"],
+        input=str(science_outside),  # absolute path outside datastore
+        start_date=datetime(2026, 1, 16),
+    )
+    verify_noop_results(temp_datastore, date=datetime(2026, 1, 16))
+
+
+def test_apply_spice_metakernel_resolved_as_datastore_relative_path(
+    temp_datastore,
+    dynamic_work_folder,
+    spice_kernels,
+):
+    """apply() must resolve the spice_metakernel when given as a path relative
+    to the datastore root (e.g. "spice/mk/metakernel.txt").
+
+    Bug: CalibrationApplicator used Path(spice_metakernel) directly, which is
+    relative to CWD.  A path like "spice/mk/metakernel.txt" would only work if
+    the CWD happened to contain that structure; it failed if the file was under
+    the datastore but not the CWD.
+    """
+    apply(
+        layers=["imap_mag_noop-norm-layer_20260116_v001.json"],
+        start_date=datetime(2026, 1, 16),
+        mode=ScienceMode.Normal,
+        save_mode=SaveMode.LocalOnly,
+        # Pass the metakernel as a datastore-relative path; CWD does NOT have this path
+        spice_metakernel=Path("spice/mk/metakernel.txt"),
+    )
+    verify_noop_results(temp_datastore, date=datetime(2026, 1, 16))

--- a/tests/test_calibration_without_matlab.py
+++ b/tests/test_calibration_without_matlab.py
@@ -11,6 +11,31 @@ from tests.util.miscellaneous import (
 )
 
 
+def _generate_layer_json(data_file_name):
+    json_contents = """
+    {
+        "id": "",
+        "metadata": {
+            "comment": "",
+            "creation_timestamp": "2025-03-28T11:22:20",
+            "data_filename": "FILENAME_PLACEHOLDER",
+            "dependencies": [],
+            "science": []
+        },
+        "method": "noop",
+        "mission": "IMAP",
+        "sensor": "MAGo",
+        "validity": {
+            "end": "2025-10-17T02:11:59.021309",
+            "start": "2025-10-17T02:11:51.521"
+        },
+        "value_type": "vector",
+        "version": 0.0
+    }
+    """
+    return json_contents.replace("FILENAME_PLACEHOLDER", data_file_name)
+
+
 def test_empty_calibrator_makes_correct_matlab_call(
     monkeypatch,
     temp_datastore,
@@ -25,7 +50,8 @@ def test_empty_calibrator_makes_correct_matlab_call(
     def mock_call_matlab(command):
         assert command.startswith("calibration.wrappers.run_empty_calibrator")
         create_test_file(
-            Path(dynamic_work_folder) / "imap_mag_noop-norm-layer_20251017_v001.json"
+            Path(dynamic_work_folder) / "imap_mag_noop-norm-layer_20251017_v001.json",
+            _generate_layer_json("imap_mag_noop-norm-layer-data_20251017_v001.csv"),
         )
         create_test_file(
             Path(dynamic_work_folder)
@@ -62,7 +88,10 @@ def test_gradiometer_calibrator_makes_correct_matlab_call(
     def mock_call_matlab(command):
         assert command.startswith("calibration.wrappers.run_gradiometry")
         create_test_file(
-            dynamic_work_folder / "imap_mag_gradiometer-norm-layer_20260930_v001.json"
+            dynamic_work_folder / "imap_mag_gradiometer-norm-layer_20260930_v001.json",
+            _generate_layer_json(
+                "imap_mag_gradiometer-norm-layer-data_20260930_v001.csv"
+            ),
         )
         create_test_file(
             dynamic_work_folder
@@ -89,7 +118,7 @@ def test_gradiometer_calibrator_makes_correct_matlab_call(
 
     layer_data = (
         temp_datastore
-        / "calibration/layers/2026/09/imap_mag_gradiometer-norm-layer_20260930_v001.json"
+        / "calibration/layers/2026/09/imap_mag_gradiometer-norm-layer-data_20260930_v001.csv"
     )
     assert layer_data.exists()
 
@@ -106,7 +135,10 @@ def test_gradiometer_calibrator_finds_next_viable_version(
         )
         create_test_file(
             Path(dynamic_work_folder)
-            / "imap_mag_gradiometer-norm-layer_20260930_v002.json"
+            / "imap_mag_gradiometer-norm-layer_20260930_v002.json",
+            _generate_layer_json(
+                "imap_mag_gradiometer-norm-layer-data_20260930_v002.csv"
+            ),
         )
         create_test_file(
             Path(dynamic_work_folder)
@@ -143,3 +175,108 @@ def test_gradiometer_calibrator_finds_next_viable_version(
         / "calibration/layers/2026/09/imap_mag_gradiometer-norm-layer_20260930_v002.json"
     )
     assert layer_data.exists()
+
+
+def test_calibration_layer_versioned_together_when_only_json_exists(
+    monkeypatch,
+    temp_datastore,
+    dynamic_work_folder,
+):
+    """Bug: when only a JSON layer exists at v001 (no CSV), both JSON and CSV
+    output files must be versioned as v002 — not JSON=v002, CSV=v001."""
+
+    def mock_call_matlab(command):
+        # Emit both files at whatever version is in the command
+        import re
+
+        m = re.search(r"layer_20260930_(v\d+)\.json", command)
+        assert m, f"Could not parse version from command: {command}"
+        ver = m.group(1)
+        create_test_file(
+            Path(dynamic_work_folder)
+            / f"imap_mag_gradiometer-norm-layer_20260930_{ver}.json",
+            _generate_layer_json(
+                f"imap_mag_gradiometer-norm-layer-data_20260930_{ver}.csv"
+            ),
+        )
+        create_test_file(
+            Path(dynamic_work_folder)
+            / f"imap_mag_gradiometer-norm-layer-data_20260930_{ver}.csv"
+        )
+
+    monkeypatch.setattr(
+        "mag_toolkit.calibration.calibrators.GradiometerCalibration.call_matlab",
+        mock_call_matlab,
+    )
+
+    # Pre-populate the datastore with only a JSON at v001 (no matching CSV)
+    layers_dir = temp_datastore / "calibration/layers/2026/09"
+    layers_dir.mkdir(parents=True, exist_ok=True)
+    (layers_dir / "imap_mag_gradiometer-norm-layer_20260930_v001.json").touch()
+
+    gradiometry(
+        start_date=datetime(2026, 9, 30),
+        mode=ScienceMode.Normal,
+        kappa=0.25,
+        sc_interference_threshold=10.0,
+    )
+
+    # Both files must share version v002
+    assert (
+        layers_dir / "imap_mag_gradiometer-norm-layer_20260930_v002.json"
+    ).exists(), "JSON layer must be v002"
+    assert (
+        layers_dir / "imap_mag_gradiometer-norm-layer-data_20260930_v002.csv"
+    ).exists(), "CSV data file must also be v002, not v001"
+
+
+def test_calibration_layer_versioned_together_when_only_csv_exists(
+    monkeypatch,
+    temp_datastore,
+    dynamic_work_folder,
+):
+    """Bug: when only a CSV layer-data exists at v001 (no JSON), both JSON and CSV
+    output files must be versioned as v002 — not JSON=v001, CSV=v002."""
+
+    def mock_call_matlab(command):
+        import re
+
+        m = re.search(r"layer_20260930_(v\d+)\.json", command)
+        assert m, f"Could not parse version from command: {command}"
+        ver = m.group(1)
+        create_test_file(
+            Path(dynamic_work_folder)
+            / f"imap_mag_gradiometer-norm-layer_20260930_{ver}.json",
+            _generate_layer_json(
+                f"imap_mag_gradiometer-norm-layer-data_20260930_{ver}.csv"
+            ),
+        )
+        create_test_file(
+            Path(dynamic_work_folder)
+            / f"imap_mag_gradiometer-norm-layer-data_20260930_{ver}.csv"
+        )
+
+    monkeypatch.setattr(
+        "mag_toolkit.calibration.calibrators.GradiometerCalibration.call_matlab",
+        mock_call_matlab,
+    )
+
+    # Pre-populate the datastore with only a CSV at v001 (no matching JSON)
+    layers_dir = temp_datastore / "calibration/layers/2026/09"
+    layers_dir.mkdir(parents=True, exist_ok=True)
+    (layers_dir / "imap_mag_gradiometer-norm-layer-data_20260930_v001.csv").touch()
+
+    gradiometry(
+        start_date=datetime(2026, 9, 30),
+        mode=ScienceMode.Normal,
+        kappa=0.25,
+        sc_interference_threshold=10.0,
+    )
+
+    # Both files must share version v002
+    assert (
+        layers_dir / "imap_mag_gradiometer-norm-layer_20260930_v002.json"
+    ).exists(), "JSON layer must be v002"
+    assert (
+        layers_dir / "imap_mag_gradiometer-norm-layer-data_20260930_v002.csv"
+    ).exists(), "CSV data file must also be v002, not v001"

--- a/tests/test_fetchIALiRT.py
+++ b/tests/test_fetchIALiRT.py
@@ -16,7 +16,7 @@ from imap_mag.download.FetchIALiRT import (
     process_ialirt_hk_data,
     process_ialirt_mag_data,
 )
-from imap_mag.io import DatastoreFileFinder
+from imap_mag.io import FileFinder
 from imap_mag.io.file import IALiRTPathHandler
 from imap_mag.util.constants import CONSTANTS
 from tests.util.miscellaneous import temp_datastore  # noqa: F401
@@ -40,7 +40,7 @@ def test_fetch_ialirt_no_data(
     fetch_ialirt = FetchIALiRT(
         mock_ialirt_data_access,
         Path(tempfile.mkdtemp()),
-        DatastoreFileFinder(Path(tempfile.mkdtemp())),
+        FileFinder(Path(tempfile.mkdtemp())),
         IALIRT_PACKET_DEFINITION,
     )
 
@@ -75,7 +75,7 @@ def test_fetch_ialirt_single_day_no_existing_data(
     fetch_ialirt = FetchIALiRT(
         mock_ialirt_data_access,
         Path(tempfile.mkdtemp()),
-        DatastoreFileFinder(temp_datastore),
+        FileFinder(temp_datastore),
         IALIRT_PACKET_DEFINITION,
     )
 
@@ -130,7 +130,7 @@ def test_fetch_ialirt_multiple_days_no_existing_data(
     fetch_ialirt = FetchIALiRT(
         mock_ialirt_data_access,
         Path(tempfile.mkdtemp()),
-        DatastoreFileFinder(temp_datastore),
+        FileFinder(temp_datastore),
         IALIRT_PACKET_DEFINITION,
     )
 
@@ -185,7 +185,7 @@ def test_fetch_ialirt_single_day_existing_older_data_in_datastore(
     fetch_ialirt = FetchIALiRT(
         mock_ialirt_data_access,
         Path(tempfile.mkdtemp()),
-        DatastoreFileFinder(temp_datastore),
+        FileFinder(temp_datastore),
         IALIRT_PACKET_DEFINITION,
     )
 
@@ -255,7 +255,7 @@ def test_fetch_ialirt_single_day_existing_older_data_in_datastore_with_more_colu
     fetch_ialirt = FetchIALiRT(
         mock_ialirt_data_access,
         Path(tempfile.mkdtemp()),
-        DatastoreFileFinder(temp_datastore),
+        FileFinder(temp_datastore),
         IALIRT_PACKET_DEFINITION,
     )
 
@@ -325,7 +325,7 @@ def test_fetch_ialirt_single_day_existing_older_data_in_datastore_with_fewer_col
     fetch_ialirt = FetchIALiRT(
         mock_ialirt_data_access,
         Path(tempfile.mkdtemp()),
-        DatastoreFileFinder(temp_datastore),
+        FileFinder(temp_datastore),
         IALIRT_PACKET_DEFINITION,
     )
 
@@ -402,7 +402,7 @@ def test_fetch_ialirt_single_day_existing_newer_data_in_datastore(
     fetch_ialirt = FetchIALiRT(
         mock_ialirt_data_access,
         Path(tempfile.mkdtemp()),
-        DatastoreFileFinder(temp_datastore),
+        FileFinder(temp_datastore),
         IALIRT_PACKET_DEFINITION,
     )
 
@@ -472,7 +472,7 @@ def test_fetch_ialirt_duplicate_timestamps_different_instruments(
     fetch_ialirt = FetchIALiRT(
         mock_ialirt_data_access,
         Path(tempfile.mkdtemp()),
-        DatastoreFileFinder(temp_datastore),
+        FileFinder(temp_datastore),
         IALIRT_PACKET_DEFINITION,
     )
 

--- a/tests/test_file_finder.py
+++ b/tests/test_file_finder.py
@@ -146,12 +146,12 @@ class TestFindScienceFile:
     def test_normal_mode_prefers_l1c(self, datastore):
         finder = FileFinder(datastore)
 
-        result = finder.find_latests_science_by_date(
+        result = finder.find_latest_science_by_date(
             datetime(2026, 1, 16), ScienceMode.Normal, MAGSensor.OBS
         )
         assert result == "imap_mag_l1c_norm-mago_20260116_v001.cdf"
 
-        result = finder.find_latests_science_by_date(
+        result = finder.find_latest_science_by_date(
             datetime(2026, 1, 16), ScienceMode.Normal, MAGSensor.IBS
         )
         assert result == "imap_mag_l1c_norm-magi_20260116_v001.cdf"
@@ -159,7 +159,7 @@ class TestFindScienceFile:
     def test_normal_mode_checks_correct_sensor(self, datastore):
         finder = FileFinder(datastore)
         with pytest.raises(FileNotFoundError):
-            finder.find_latests_science_by_date(
+            finder.find_latest_science_by_date(
                 datetime(2026, 1, 17), ScienceMode.Normal, MAGSensor.IBS
             )
 
@@ -170,14 +170,14 @@ class TestFindScienceFile:
         (l1b_dir / "imap_mag_l1b_norm-mago_20260116_v000.cdf").touch()
 
         finder = FileFinder(tmp_path)
-        result = finder.find_latests_science_by_date(
+        result = finder.find_latest_science_by_date(
             datetime(2026, 1, 16), ScienceMode.Normal, MAGSensor.OBS
         )
         assert result == "imap_mag_l1b_norm-mago_20260116_v000.cdf"
 
     def test_burst_mode_uses_l1b_only(self, datastore):
         finder = FileFinder(datastore)
-        result = finder.find_latests_science_by_date(
+        result = finder.find_latest_science_by_date(
             datetime(2026, 1, 16), ScienceMode.Burst, MAGSensor.OBS
         )
         assert result == "imap_mag_l1b_burst-mago_20260116_v002.cdf"
@@ -190,7 +190,7 @@ class TestFindScienceFile:
 
         finder = FileFinder(tmp_path)
         with pytest.raises(FileNotFoundError):
-            finder.find_latests_science_by_date(
+            finder.find_latest_science_by_date(
                 datetime(2026, 1, 16), ScienceMode.Burst, MAGSensor.OBS
             )
 
@@ -202,7 +202,7 @@ class TestFindScienceFile:
         (l1c_dir / "imap_mag_l1c_norm-mago_20260116_v001.cdf").touch()
 
         finder = FileFinder(tmp_path)
-        result = finder.find_latests_science_by_date(
+        result = finder.find_latest_science_by_date(
             datetime(2026, 1, 16), ScienceMode.Normal, MAGSensor.OBS
         )
         assert result == "imap_mag_l1c_norm-mago_20260116_v003.cdf"
@@ -216,7 +216,7 @@ class TestFindScienceFile:
         (l1c_dir / "README.md").touch()
 
         finder = FileFinder(tmp_path)
-        result = finder.find_latests_science_by_date(
+        result = finder.find_latest_science_by_date(
             datetime(2026, 1, 16), ScienceMode.Normal, MAGSensor.OBS
         )
         assert result == "imap_mag_l1c_norm-mago_20260116_v001.cdf"
@@ -224,7 +224,7 @@ class TestFindScienceFile:
     def test_no_science_dir_raises(self, tmp_path):
         finder = FileFinder(tmp_path)
         with pytest.raises(FileNotFoundError, match="Science directory"):
-            finder.find_latests_science_by_date(
+            finder.find_latest_science_by_date(
                 datetime(2026, 1, 16), ScienceMode.Normal, MAGSensor.OBS
             )
 
@@ -236,6 +236,6 @@ class TestFindScienceFile:
 
         finder = FileFinder(tmp_path)
         with pytest.raises(FileNotFoundError, match="No science file found"):
-            finder.find_latests_science_by_date(
+            finder.find_latest_science_by_date(
                 datetime(2026, 1, 16), ScienceMode.Normal, MAGSensor.OBS
             )

--- a/tests/test_file_finder.py
+++ b/tests/test_file_finder.py
@@ -2,7 +2,7 @@ from datetime import datetime
 
 import pytest
 
-from imap_mag.io.DatastoreFileFinder import DatastoreFileFinder
+from imap_mag.io.FileFinder import FileFinder
 from imap_mag.util import MAGSensor, ScienceMode
 
 
@@ -46,8 +46,8 @@ def datastore(tmp_path):
 
 class TestResolveLayerPatterns:
     def test_exact_filename_passes_through(self, datastore):
-        finder = DatastoreFileFinder(datastore)
-        result = finder.find_layers(
+        finder = FileFinder(datastore)
+        result = finder.find_layers_by_date_and_patterns(
             ["imap_mag_noop-burst-layer_20260116_v001.json"],
             datetime(2026, 1, 16),
             ScienceMode.Burst,
@@ -55,8 +55,8 @@ class TestResolveLayerPatterns:
         assert result == ["imap_mag_noop-burst-layer_20260116_v001.json"]
 
     def test_wildcard_returns_highest_version_per_descriptor(self, datastore):
-        finder = DatastoreFileFinder(datastore)
-        result = finder.find_layers(
+        finder = FileFinder(datastore)
+        result = finder.find_layers_by_date_and_patterns(
             ["*noop*"],
             datetime(2026, 1, 16),
             ScienceMode.Normal,
@@ -65,8 +65,8 @@ class TestResolveLayerPatterns:
         assert result == ["imap_mag_noop-norm-layer_20260116_v002.json"]
 
     def test_wildcard_star_returns_all_descriptors_highest_versions(self, datastore):
-        finder = DatastoreFileFinder(datastore)
-        result = finder.find_layers(
+        finder = FileFinder(datastore)
+        result = finder.find_layers_by_date_and_patterns(
             ["*"],
             datetime(2026, 1, 16),
             ScienceMode.Normal,
@@ -77,8 +77,8 @@ class TestResolveLayerPatterns:
         assert len(result) == 2
 
     def test_no_match_returns_empty(self, datastore):
-        finder = DatastoreFileFinder(datastore)
-        result = finder.find_layers(
+        finder = FileFinder(datastore)
+        result = finder.find_layers_by_date_and_patterns(
             ["*nonexistent*"],
             datetime(2026, 1, 16),
             ScienceMode.Normal,
@@ -86,8 +86,8 @@ class TestResolveLayerPatterns:
         assert result == []
 
     def test_missing_directory_returns_empty(self, datastore):
-        finder = DatastoreFileFinder(datastore)
-        result = finder.find_layers(
+        finder = FileFinder(datastore)
+        result = finder.find_layers_by_date_and_patterns(
             ["*"],
             datetime(2025, 3, 15),
             ScienceMode.Normal,
@@ -95,8 +95,8 @@ class TestResolveLayerPatterns:
         assert result == []
 
     def test_mixed_exact_and_wildcard(self, datastore):
-        finder = DatastoreFileFinder(datastore)
-        result = finder.find_layers(
+        finder = FileFinder(datastore)
+        result = finder.find_layers_by_date_and_patterns(
             ["imap_mag_noop-burst-layer_20260116_v001.json", "*quality*"],
             datetime(2026, 1, 16),
             ScienceMode.Burst,
@@ -115,7 +115,7 @@ class TestKeepHighestVersions:
             "imap_mag_noop-layer_20260116_v002.json",
             "imap_mag_noop-layer_20260116_v000.json",
         ]
-        result = DatastoreFileFinder._keep_highest_version_layers_only(filenames)
+        result = FileFinder._keep_highest_version_layers_only(filenames)
         assert result == ["imap_mag_noop-layer_20260116_v002.json"]
 
     def test_multiple_descriptors(self):
@@ -125,41 +125,41 @@ class TestKeepHighestVersions:
             "imap_mag_quality-layer_20260116_v000.json",
             "imap_mag_quality-layer_20260116_v001.json",
         ]
-        result = DatastoreFileFinder._keep_highest_version_layers_only(filenames)
+        result = FileFinder._keep_highest_version_layers_only(filenames)
         assert len(result) == 2
         assert "imap_mag_noop-layer_20260116_v003.json" in result
         assert "imap_mag_quality-layer_20260116_v001.json" in result
 
     def test_empty_list(self):
-        assert DatastoreFileFinder._keep_highest_version_layers_only([]) == []
+        assert FileFinder._keep_highest_version_layers_only([]) == []
 
     def test_unparseable_filenames_skipped(self):
         filenames = [
             "imap_mag_noop-layer_20260116_v001.json",
             "not_a_valid_layer_file.json",
         ]
-        result = DatastoreFileFinder._keep_highest_version_layers_only(filenames)
+        result = FileFinder._keep_highest_version_layers_only(filenames)
         assert result == ["imap_mag_noop-layer_20260116_v001.json"]
 
 
 class TestFindScienceFile:
     def test_normal_mode_prefers_l1c(self, datastore):
-        finder = DatastoreFileFinder(datastore)
+        finder = FileFinder(datastore)
 
-        result = finder.find_science_file(
+        result = finder.find_latests_science_by_date(
             datetime(2026, 1, 16), ScienceMode.Normal, MAGSensor.OBS
         )
         assert result == "imap_mag_l1c_norm-mago_20260116_v001.cdf"
 
-        result = finder.find_science_file(
+        result = finder.find_latests_science_by_date(
             datetime(2026, 1, 16), ScienceMode.Normal, MAGSensor.IBS
         )
         assert result == "imap_mag_l1c_norm-magi_20260116_v001.cdf"
 
     def test_normal_mode_checks_correct_sensor(self, datastore):
-        finder = DatastoreFileFinder(datastore)
+        finder = FileFinder(datastore)
         with pytest.raises(FileNotFoundError):
-            finder.find_science_file(
+            finder.find_latests_science_by_date(
                 datetime(2026, 1, 17), ScienceMode.Normal, MAGSensor.IBS
             )
 
@@ -169,15 +169,15 @@ class TestFindScienceFile:
         l1b_dir.mkdir(parents=True)
         (l1b_dir / "imap_mag_l1b_norm-mago_20260116_v000.cdf").touch()
 
-        finder = DatastoreFileFinder(tmp_path)
-        result = finder.find_science_file(
+        finder = FileFinder(tmp_path)
+        result = finder.find_latests_science_by_date(
             datetime(2026, 1, 16), ScienceMode.Normal, MAGSensor.OBS
         )
         assert result == "imap_mag_l1b_norm-mago_20260116_v000.cdf"
 
     def test_burst_mode_uses_l1b_only(self, datastore):
-        finder = DatastoreFileFinder(datastore)
-        result = finder.find_science_file(
+        finder = FileFinder(datastore)
+        result = finder.find_latests_science_by_date(
             datetime(2026, 1, 16), ScienceMode.Burst, MAGSensor.OBS
         )
         assert result == "imap_mag_l1b_burst-mago_20260116_v002.cdf"
@@ -188,9 +188,9 @@ class TestFindScienceFile:
         l1c_dir.mkdir(parents=True)
         (l1c_dir / "imap_mag_l1c_burst-mago_20260116_v001.cdf").touch()
 
-        finder = DatastoreFileFinder(tmp_path)
+        finder = FileFinder(tmp_path)
         with pytest.raises(FileNotFoundError):
-            finder.find_science_file(
+            finder.find_latests_science_by_date(
                 datetime(2026, 1, 16), ScienceMode.Burst, MAGSensor.OBS
             )
 
@@ -201,8 +201,8 @@ class TestFindScienceFile:
         (l1c_dir / "imap_mag_l1c_norm-mago_20260116_v003.cdf").touch()
         (l1c_dir / "imap_mag_l1c_norm-mago_20260116_v001.cdf").touch()
 
-        finder = DatastoreFileFinder(tmp_path)
-        result = finder.find_science_file(
+        finder = FileFinder(tmp_path)
+        result = finder.find_latests_science_by_date(
             datetime(2026, 1, 16), ScienceMode.Normal, MAGSensor.OBS
         )
         assert result == "imap_mag_l1c_norm-mago_20260116_v003.cdf"
@@ -215,16 +215,16 @@ class TestFindScienceFile:
         (l1c_dir / "imap_mag_l1c_norm-mago_20260116_v001.txt").touch()
         (l1c_dir / "README.md").touch()
 
-        finder = DatastoreFileFinder(tmp_path)
-        result = finder.find_science_file(
+        finder = FileFinder(tmp_path)
+        result = finder.find_latests_science_by_date(
             datetime(2026, 1, 16), ScienceMode.Normal, MAGSensor.OBS
         )
         assert result == "imap_mag_l1c_norm-mago_20260116_v001.cdf"
 
     def test_no_science_dir_raises(self, tmp_path):
-        finder = DatastoreFileFinder(tmp_path)
+        finder = FileFinder(tmp_path)
         with pytest.raises(FileNotFoundError, match="Science directory"):
-            finder.find_science_file(
+            finder.find_latests_science_by_date(
                 datetime(2026, 1, 16), ScienceMode.Normal, MAGSensor.OBS
             )
 
@@ -234,8 +234,8 @@ class TestFindScienceFile:
         # File for wrong date
         (science_dir / "imap_mag_l1c_norm-mago_20260115_v001.cdf").touch()
 
-        finder = DatastoreFileFinder(tmp_path)
+        finder = FileFinder(tmp_path)
         with pytest.raises(FileNotFoundError, match="No science file found"):
-            finder.find_science_file(
+            finder.find_latests_science_by_date(
                 datetime(2026, 1, 16), ScienceMode.Normal, MAGSensor.OBS
             )

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
-from imap_mag.io import DatastoreFileFinder
+from imap_mag.io import FileFinder
 from imap_mag.io.file import HKDecodedPathHandler, IFilePathHandler
 from imap_mag.process import HKProcessor, dispatch
 from imap_mag.util import CONSTANTS, HKPacket, TimeConversion
@@ -22,7 +22,7 @@ def instantiate_hk_processor(test_datastore: Path = DATASTORE) -> HKProcessor:
 
     work_folder = Path(tempfile.gettempdir())
 
-    processor = HKProcessor(work_folder, DatastoreFileFinder(test_datastore))
+    processor = HKProcessor(work_folder, FileFinder(test_datastore))
     processor.initialize(Path("packet_def"))
 
     return processor
@@ -60,7 +60,7 @@ def test_dispatch_hk_binary(extension):
     processor = dispatch(
         packet_path,
         Path(tempfile.gettempdir()),
-        DatastoreFileFinder(DATASTORE),
+        FileFinder(DATASTORE),
     )
 
     # Verify.
@@ -81,7 +81,7 @@ def test_dispatch_unsupported_file(capture_cli_logs):
         dispatch(
             packet_path,
             Path(tempfile.gettempdir()),
-            DatastoreFileFinder(DATASTORE),
+            FileFinder(DATASTORE),
         )
 
     assert (

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -1,6 +1,7 @@
 import json
 import os
 import re
+import shutil
 from pathlib import Path
 
 import pytest
@@ -16,12 +17,16 @@ from imap_mag.cli.publish import publish
 from imap_mag.main import app
 from imap_mag.util import Environment
 from prefect_server.publishFlow import publish_flow
+from tests.util.database import test_database  # noqa: F401
 from tests.util.miscellaneous import (
     DATASTORE,
 )
 from tests.util.prefect_test_utils import prefect_test_fixture  # noqa: F401
 
 runner = CliRunner()
+
+OFFSETS_FILENAME = "imap_mag_l2-norm-offsets_20251017_20251017_v001.cdf"
+OFFSETS_DATASTORE_PATH = Path("science-ancillary/l2-offsets/2025/10") / OFFSETS_FILENAME
 
 
 def add_mapping_for_successful_sdc_upload(wiremock_manager, upload_file: Path):
@@ -180,3 +185,38 @@ async def test_publish_flow_to_sdc(
 
     # Verify.
     assert f"Publishing 1 files: {upload_file}" in capture_cli_logs.text
+
+
+@pytest.mark.skipif(
+    os.getenv("GITHUB_ACTIONS") and os.getenv("RUNNER_OS") == "Windows",
+    reason="Wiremock test containers will not work on Windows Github Runner",
+)
+def test_publish_resolves_absolute_path_to_offsets_file(
+    wiremock_manager,
+    capture_cli_logs,
+    temp_datastore,
+    dynamic_work_folder,
+):
+    # Create the offsets file in the temp datastore
+    offsets_in_datastore = temp_datastore / OFFSETS_DATASTORE_PATH
+    offsets_in_datastore.parent.mkdir(parents=True, exist_ok=True)
+    offsets_in_datastore.write_bytes(b"fake-cdf-content")
+
+    # Copy the file to a location outside the datastore
+    outside = dynamic_work_folder / OFFSETS_FILENAME
+    shutil.copy(offsets_in_datastore, outside)
+
+    # Remove the file from the datastore so only the external copy exists
+    offsets_in_datastore.unlink()
+
+    add_mapping_for_successful_sdc_upload(wiremock_manager, Path(OFFSETS_FILENAME))
+
+    # publish() must succeed using the absolute path directly
+    with Environment(
+        MAG_DATA_STORE=str(temp_datastore),
+        MAG_PUBLISH_API_URL_BASE=wiremock_manager.get_url(),
+        IMAP_API_KEY="12345",
+    ):
+        publish([outside])
+
+    assert f"Publishing 1 files: {outside}" in capture_cli_logs.text

--- a/tests/test_setQualityAndNan.py
+++ b/tests/test_setQualityAndNan.py
@@ -10,6 +10,7 @@ from imap_mag.cli.apply import apply
 from imap_mag.cli.calibrate import calibrate
 from imap_mag.config import SaveMode
 from imap_mag.config.CalibrationConfig import CalibrationConfig, SetQualityAndNaNConfig
+from imap_mag.io.file.CalibrationLayerPathHandler import CalibrationLayerPathHandler
 from imap_mag.util import ScienceMode
 from mag_toolkit.calibration import (
     CalibrationLayer,
@@ -285,7 +286,7 @@ def test_run_calibration_raises_for_missing_csv(tmp_path):
         set_quality_and_nan=SetQualityAndNaNConfig(csv_file="/nonexistent/file.csv")
     )
 
-    with pytest.raises(FileNotFoundError, match="CSV file not found"):
+    with pytest.raises(FileNotFoundError, match="File not found"):
         job.run_calibration(handler, config)
 
 
@@ -557,3 +558,40 @@ def test_calibrate_and_apply_set_quality_and_nan_end_to_end(
 
     finally:
         csv_path.unlink(missing_ok=True)
+
+
+def test_quality_calibration_csv_resolved_from_cwd(monkeypatch, tmp_path):
+    csv = tmp_path / "my_quality_events.csv"
+    csv.write_text(
+        "start_date,end_date,quality_flag,quality_bitmask,nan_x,nan_y,nan_z\n"
+        "2026-01-16T02:00:00,2026-01-16T04:00:00,2,3,True,False,False\n"
+    )
+
+    # Change CWD to the directory that contains the CSV so the bare filename resolves
+    monkeypatch.chdir(tmp_path)
+
+    # Use a separate directory as the datastore so the CSV is NOT there
+    datastore = tmp_path / "store"
+    datastore.mkdir()
+    params = CalibrationJobParameters(
+        date=datetime(2026, 1, 16), mode=ScienceMode.Normal, sensor=Sensor.MAGO
+    )
+    work = tmp_path / "work"
+    work.mkdir()
+    job = SetQualityAndNaNCalibrationJob(params, work)
+    job.setup_datastore(datastore)  # CSV is not here
+    handler = CalibrationLayerPathHandler(
+        descriptor=CalibrationMethod.SET_QUALITY_AND_NAN.short_name,
+        content_date=datetime(2026, 1, 16),
+    )
+    config = CalibrationConfig(
+        set_quality_and_nan=SetQualityAndNaNConfig(csv_file="my_quality_events.csv")
+    )
+
+    # Should succeed: resolver finds the file via CWD fallback
+    calfile, datafile = job.run_calibration(handler, config)
+
+    assert calfile.exists()
+    assert datafile.exists()
+    df = pd.read_csv(datafile)
+    assert len(df) == 2  # start + end change points


### PR DESCRIPTION
- Ensure that all places we pass filenames (science, layer,spice mk) in cal process cli and prefect ui accept both abs paths, datastore relative paths and just file names which are resolved dynamically
- Ensure layer json and csv files never have a different version number