### PR TITLE
fix: Ensure ialirt errors when zero checks are performed

### DIFF
--- a/src/imap_mag/check/check_ialirt_files.py
+++ b/src/imap_mag/check/check_ialirt_files.py
@@ -51,6 +51,7 @@ def check_ialirt_files(
     validation: dict = packet_definition["ialirt_validation"]
 
     # Check parameters according to validation rules
+    checks_run = 0
     for parameter in validation:
         name = parameter["name"]
         type = parameter["type"]
@@ -58,6 +59,8 @@ def check_ialirt_files(
         if name not in ialirt_data.columns:
             logger.warning(f"Parameter {name} not found in I-ALiRT data columns.")
             continue
+
+        checks_run += 1
 
         match type:
             case "limit":  # ------- Check for out-of-bounds values -------
@@ -125,6 +128,11 @@ def check_ialirt_files(
 
             case _:  # ------- Unknown check -------
                 logger.error(f"Unknown validation type {type} for parameter {name}.")
+
+    if checks_run == 0:
+        raise RuntimeError(
+            "No checks were performed — no matching columns found in I-ALiRT data."
+        )
 
     return anomalies
 

--- a/src/imap_mag/packet_def/ialirt_4.05.yaml
+++ b/src/imap_mag/packet_def/ialirt_4.05.yaml
@@ -18,8 +18,8 @@ ialirt_human_readable_names:
   - mag_hk_multbit_errs: Multi-bit Errors
   - mag_hk_fib_saturated: FIB Saturation
   - mag_hk_fob_saturated: FOB Saturation
-  - mag_hk_fib_isvalid: FIB Status
-  - mag_hk_fob_isvalid: FOB Status
+  - mag_hk_pri_isvalid: FIB Status
+  - mag_hk_sec_isvalid: FOB Status
 
 ialirt_csv_conversion:
   columns:
@@ -87,11 +87,8 @@ ialirt_validation:
     warning_max: 55
   - name: mag_hk_mode
     type: forbidden
-    values: [2, 4]
+    values: ["Safe", "Debug"]
     severity: danger
-    lookup:
-      2: Safe
-      4: Debug
   - name: mag_hk_hk1v5_danger
     type: flag
     severity: danger

--- a/src/imap_mag/packet_def/ialirt_4.05.yaml
+++ b/src/imap_mag/packet_def/ialirt_4.05.yaml
@@ -18,8 +18,8 @@ ialirt_human_readable_names:
   - mag_hk_multbit_errs: Multi-bit Errors
   - mag_hk_fib_saturated: FIB Saturation
   - mag_hk_fob_saturated: FOB Saturation
-  - mag_hk_pri_isvalid: FIB Status
-  - mag_hk_sec_isvalid: FOB Status
+  - mag_hk_pri_isvalid: FOB Status
+  - mag_hk_sec_isvalid: FIB Status
 
 ialirt_csv_conversion:
   columns:

--- a/src/imap_mag/packet_def/ialirt_4.05_unittest.yaml
+++ b/src/imap_mag/packet_def/ialirt_4.05_unittest.yaml
@@ -89,11 +89,8 @@ ialirt_validation:
     danger_max: 59
   - name: mag_hk_mode
     type: forbidden
-    values: [2, 4]
+    values: ["Safe", "Debug"]
     severity: warning
-    lookup:
-      2: Safe
-      4: Debug
   - name: mag_hk_hk1v5_danger
     type: flag
     severity: danger

--- a/src/prefect_server/constants.py
+++ b/src/prefect_server/constants.py
@@ -15,7 +15,6 @@ class PREFECT_CONSTANTS:
 
     class EVENT:
         FLOW_RUN_COMPLETED = "prefect.flow-run.Completed"
-        IALIRT_UPDATED = "imap_mag.ialirt.updated"
         IALIRT_HK_UPDATED = "imap_mag.ialirt_hk.updated"
 
     class POLL_IALIRT:

--- a/src/prefect_server/pollIALiRT.py
+++ b/src/prefect_server/pollIALiRT.py
@@ -302,7 +302,7 @@ def do_poll_ialirt(
         logger=logger,
         progress_item_id=CONSTANTS.DATABASE.IALIRT_PROGRESS_ID,
         fetch_fn=fetch_ialirt,
-        event_type=PREFECT_CONSTANTS.EVENT.IALIRT_UPDATED,
+        event_type=None,
     )
 
 
@@ -336,7 +336,7 @@ def _do_poll(
     logger,
     progress_item_id: str,
     fetch_fn,
-    event_type: str,
+    event_type: str | None,
 ) -> list[Path]:
     start_timestamp = DatetimeProvider.now()
 
@@ -391,19 +391,21 @@ def _do_poll(
     )
 
     # Trigger event to notify updated I-ALiRT data
-    logger.debug(f"Emitting {event_type} event")
+    if event_type is not None:
+        logger.debug(f"Emitting {event_type} event")
 
-    event: Event | None = emit_event(
-        event=event_type,
-        resource={
-            "prefect.resource.id": f"prefect.flow-run.{flow_run.id}",
-            "prefect.resource.name": flow_run.name,
-            "prefect.resource.role": "flow-run",
-        },
-        payload={"files": list(downloaded.keys())},
-    )
-
-    if event is None:
-        logger.warning(f"Failed to emit {event_type} event")
+        event: Event | None = emit_event(
+            event=event_type,
+            resource={
+                "prefect.resource.id": f"prefect.flow-run.{flow_run.id}",
+                "prefect.resource.name": flow_run.name,
+                "prefect.resource.role": "flow-run",
+            },
+            payload={"files": list(downloaded.keys())},
+        )
+        if event is None:
+            logger.error(f"Failed to emit {event_type} event")
+    else:
+        event = None
 
     return list(downloaded.keys())

--- a/src/prefect_server/workflow.py
+++ b/src/prefect_server/workflow.py
@@ -239,7 +239,7 @@ async def adeploy_flows(local_debug: bool = False):
         triggers=[
             DeploymentEventTrigger(
                 name="Trigger I-ALiRT validation on I-ALiRT update",
-                expect={PREFECT_CONSTANTS.EVENT.IALIRT_UPDATED},
+                expect={PREFECT_CONSTANTS.EVENT.IALIRT_HK_UPDATED},
                 match_related={
                     "prefect.resource.name": PREFECT_CONSTANTS.FLOW_NAMES.POLL_IALIRT
                 },  # type: ignore

--- a/tests/test_check_ialirt_files.py
+++ b/tests/test_check_ialirt_files.py
@@ -228,6 +228,24 @@ def test_check_ialirt_files_with_anomalies(
     assert anomalies[0] == expected_anomaly
 
 
+def test_check_ialirt_raises_error_when_no_checks_run(temp_folder_path) -> None:
+    # Set up: YAML has known params, but CSV has completely different columns.
+    write_test_ialirt_packet_definition_file(temp_folder_path)
+    test_ialirt_data: Path = temp_folder_path / "ialirt_data.csv"
+    test_ialirt_data.write_text(
+        "time_utc,unrelated_column_a,unrelated_column_b\n"
+        "2024-01-01T00:00:00,1,2\n"
+        "2024-01-01T01:00:00,3,4\n"
+    )
+
+    # Exercise and verify.
+    with pytest.raises(RuntimeError, match="No checks were performed"):
+        check_ialirt_files(
+            files=[test_ialirt_data],
+            packet_definition_folder=temp_folder_path,
+        )
+
+
 def test_check_ialirt_files_unknown_validation_type(temp_folder_path, caplog) -> None:
     # Set up.
     packet_definition_file: Path = (


### PR DESCRIPTION
- Fix mag_hk_mode forbidden check: CSV now emits string values ("Safe", "Debug") after the poll ialirt HK schema change, replacing the old integer mapping values [2, 4] that never fired
- Raise RuntimeError in check_ialirt_files when no validation rules matched any CSV column, preventing silent no-op runs
- trigger the check flow with a hk file not a science file as the science files cannot be checked