### PR TITLE
fix: layer data file version is locked once chosen even when identical file already exists

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 requires-python = ">=3.11,<3.15"
 name = "imap-mag"
-version = "5.1.0"
+version = "5.1.1"
 description = "Process IMAP data"
 authors = [
   {name = "alastairtree"},

--- a/src/imap_mag/cli/calibrate.py
+++ b/src/imap_mag/cli/calibrate.py
@@ -174,6 +174,9 @@ def _calibrate_for_date(
 
     calibrator.setup_calibration_files(datastore_finder)
     calibrator.setup_datastore(app_settings.data_store)
+    outputManager = DatastoreFileManager.CreateByMode(
+        app_settings, use_database=save_mode == SaveMode.LocalAndDatabase
+    )
 
     calibration_handler = CalibrationLayerPathHandler(
         descriptor=f"{method.short_name}-{mode.value}", content_date=start_date
@@ -194,10 +197,6 @@ def _calibrate_for_date(
         raise ValueError(
             f"Calibration layer metadata file {metadata_path!s} specifies data file {layer.metadata.data_filename!s} but actual data file is {data_path!s}."
         )
-
-    outputManager = DatastoreFileManager.CreateByMode(
-        app_settings, use_database=save_mode == SaveMode.LocalAndDatabase
-    )
 
     (output_calibration_path, _) = outputManager.add_file(
         metadata_path, path_handler=calibration_handler

--- a/src/imap_mag/io/DBIndexedDatastoreFileManager.py
+++ b/src/imap_mag/io/DBIndexedDatastoreFileManager.py
@@ -223,11 +223,16 @@ class DBIndexedDatastoreFileManager(IDatastoreFileManager):
         matching_files: list[File] = [
             f for f in database_files if f.hash == original_hash
         ]
+
         assert len(matching_files) <= 1, (
             "There should be at most one file with the same hash in the database."
         )
 
+        # This is a versioned file - if we already have a copy of the file with same content by hash, we can just reuse that version and skip copying and database insertion
         if matching_files:
+            logger.info(
+                f"File with same content as {original_file.name} already exists in database with version {matching_files[0].version}. Reusing that version."
+            )
             path_handler.set_sequence(matching_files[0].version)
             preliminary_file = path_handler.get_full_path(Path(""))
 

--- a/src/imap_mag/io/file/CalibrationLayerPathHandler.py
+++ b/src/imap_mag/io/file/CalibrationLayerPathHandler.py
@@ -68,6 +68,7 @@ class CalibrationLayerPathHandler(VersionedPathHandler):
             content_date=self.content_date,
             version=self.version,
             extension="csv",
+            _version_is_locked=self._version_is_locked,
         )
 
     @classmethod

--- a/src/imap_mag/io/file/VersionedPathHandler.py
+++ b/src/imap_mag/io/file/VersionedPathHandler.py
@@ -12,21 +12,38 @@ class VersionedPathHandler(SequenceablePathHandler):
     """
 
     version: int = 1
+    _version_is_locked: bool = False
 
     def get_sequence(self) -> int:
         return self.version
 
+    def lock_version(self) -> None:
+        self._version_is_locked = True
+
     def set_sequence(self, sequence: int) -> None:
+        if self._version_is_locked:
+            raise ValueError("Version is locked and cannot be changed.")
+
         if not self.supports_sequencing():
             raise ValueError("This path handler does not support sequencing.")
 
         self.version = sequence
 
     def increase_sequence(self) -> None:
+        if self._version_is_locked:
+            raise ValueError("Version is locked and cannot be changed.")
+
         if not self.supports_sequencing():
             raise ValueError("This path handler does not support sequencing.")
 
         self.version += 1
+
+    def supports_sequencing(self) -> bool:
+
+        if self._version_is_locked:
+            return False
+
+        return super().supports_sequencing()
 
     @staticmethod
     def get_sequence_variable_name() -> str:

--- a/src/mag_toolkit/calibration/calibrators/CalibrationJob.py
+++ b/src/mag_toolkit/calibration/calibrators/CalibrationJob.py
@@ -93,8 +93,10 @@ class CalibrationJob(ABC):
             _version_of(latest_json_file), _version_of(latest_csv_file)
         )
         if max_existing_version >= layer_handler.version:
-            layer_handler.version = max_existing_version
+            layer_handler.set_sequence(max_existing_version)
             layer_handler.increase_sequence()
+
+        layer_handler.lock_version()
 
     def _check_environment_is_setup(self):
         if not self._check_for_required_files():

--- a/tests/test_setQualityAndNan.py
+++ b/tests/test_setQualityAndNan.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 from datetime import datetime
 from pathlib import Path
@@ -20,6 +21,7 @@ from mag_toolkit.calibration import (
 )
 from mag_toolkit.calibration.CalibrationDefinitions import CONSTANTS, ValueType
 from mag_toolkit.calibration.CalibrationJobParameters import CalibrationJobParameters
+from tests.util.database import test_database  # noqa: F401
 from tests.util.miscellaneous import open_cdf
 
 
@@ -862,5 +864,50 @@ def test_quality_calibration_csv_resolved_from_cwd(monkeypatch, tmp_path):
 
     assert calfile.exists()
     assert datafile.exists()
-    df = pd.read_csv(datafile)
-    assert len(df) == 2  # start + end change points
+    pd.read_csv(datafile)
+
+
+@pytest.mark.skipif(
+    os.getenv("GITHUB_ACTIONS") and os.getenv("RUNNER_OS") == "Windows",
+    reason="Test containers (used by test database) does not work on Windows",
+)
+def test_calibrate_twice_with_database_creates_v002_layer_and_data_files(
+    temp_datastore,
+    dynamic_work_folder,
+    test_database,  # noqa: F811
+):
+    csv_content = (
+        "start_date,end_date,quality_flag,quality_bitmask,nan_x,nan_y,nan_z\n"
+        "2026-01-16T02:11:54,2026-01-16T02:11:57,1,3,True,False,False\n"
+    )
+    config = create_temporary_csv_config(csv_content)
+    date = datetime(2026, 1, 16)
+    layer_dir = temp_datastore / "calibration" / "layers" / "2026" / "01"
+
+    calibrate(
+        start_date=date,
+        method=CalibrationMethod.SET_QUALITY_AND_NAN,
+        mode=ScienceMode.Normal,
+        sensor=Sensor.MAGO,
+        configuration=config.model_dump_json(),
+        save_mode=SaveMode.LocalAndDatabase,
+    )
+
+    calibrate(
+        start_date=date,
+        method=CalibrationMethod.SET_QUALITY_AND_NAN,
+        mode=ScienceMode.Normal,
+        sensor=Sensor.MAGO,
+        configuration=config.model_dump_json(),
+        save_mode=SaveMode.LocalAndDatabase,
+    )
+
+    v002_json = layer_dir / "imap_mag_quality-norm-layer_20260116_v002.json"
+    v002_csv = layer_dir / "imap_mag_quality-norm-layer-data_20260116_v002.csv"
+    assert v002_json.exists(), "Second run must produce layer JSON at v002"
+    assert v002_csv.exists(), "Second run must produce layer data CSV at v002"
+
+    layer = CalibrationLayer.from_file(v002_json, load_contents=False)
+    assert layer.metadata.data_filename.name == v002_csv.name, (
+        "Layer JSON v002 must reference data CSV v002, not an older version"
+    )


### PR DESCRIPTION
When running SetQualityAndNaN calibration twice with SaveMode.LocalAndDatabase, the second run produced identical data CSV content. DBIndexedDatastoreFileManager found a hash match at v001 in the DB and redirected the handler back to v001, while the layer JSON had already been written referencing data_filename=v002.csv. Fixed by allowing layer files version to be locked.

Bumps version to 5.1.1.