### PR TITLE
feature: add multi-instrument I-ALiRT pipeline for HIT, SWE, SWAPI an…

### DIFF
--- a/imap-db-ingest-config.yaml
+++ b/imap-db-ingest-config.yaml
@@ -11027,7 +11027,7 @@ jobs:
           use_to_delete_old_rows: true
   imap_ialirt:
     target_table: ialirt_mag
-    filename_match: imap_ialirt_*.csv
+    filename_match: imap_ialirt_2*.csv
     id_mapping:
       time_utc:
         db_column: time_utc

--- a/imap-db-ingest-config.yaml
+++ b/imap-db-ingest-config.yaml
@@ -11109,3 +11109,247 @@ jobs:
           db_column: file_date
           type: date
           use_to_delete_old_rows: true
+  imap_ialirt_hit:
+    target_table: imap_ialirt_hit
+    id_mapping:
+      time_utc:
+        db_column: id
+        type: datetime
+        nullable: false
+    columns:
+      hit_e_a_side_med_en:
+        db_column: hit_e_a_side_med_en
+        type: integer
+        nullable: false
+      hit_e_b_side_med_en:
+        db_column: hit_e_b_side_med_en
+        type: integer
+        nullable: false
+      hit_epoch:
+        db_column: hit_epoch
+        type: bigint
+        nullable: false
+      hit_h_omni_low_en:
+        db_column: hit_h_omni_low_en
+        type: integer
+        nullable: false
+      hit_h_omni_med_en:
+        db_column: hit_h_omni_med_en
+        type: integer
+        nullable: false
+      hit_he_omni_high_en:
+        db_column: hit_he_omni_high_en
+        type: integer
+        nullable: false
+      hit_he_omni_low_en:
+        db_column: hit_he_omni_low_en
+        type: integer
+        nullable: false
+      instrument:
+        db_column: instrument
+        type: varchar(3)
+        nullable: false
+      kernel_set_key:
+        db_column: kernel_set_key
+        type: datetime
+        nullable: false
+      ttj2000ns:
+        db_column: ttj2000ns
+        type: bigint
+        nullable: false
+    filename_to_column:
+      template: imap_ialirt_hit_[date].csv
+      columns:
+        date:
+          db_column: file_date
+          type: date
+          use_to_delete_old_rows: true
+    indexes:
+    - name: idx_kernel_set_key
+      columns:
+      - column: kernel_set_key
+        order: DESC
+  imap_ialirt_swe:
+    target_table: imap_ialirt_swe
+    id_mapping:
+      time_utc:
+        db_column: id
+        type: datetime
+        nullable: false
+    columns:
+      instrument:
+        db_column: instrument
+        type: varchar(3)
+        nullable: false
+      kernel_set_key:
+        db_column: kernel_set_key
+        type: datetime
+        nullable: false
+      swe_counterstreaming_electrons:
+        db_column: swe_counterstreaming_electrons
+        type: integer
+        nullable: false
+      swe_epoch:
+        db_column: swe_epoch
+        type: bigint
+        nullable: false
+      swe_normalized_counts_0:
+        db_column: swe_normalized_counts_0
+        type: integer
+        nullable: false
+      swe_normalized_counts_1:
+        db_column: swe_normalized_counts_1
+        type: integer
+        nullable: false
+      swe_normalized_counts_2:
+        db_column: swe_normalized_counts_2
+        type: integer
+        nullable: false
+      swe_normalized_counts_3:
+        db_column: swe_normalized_counts_3
+        type: integer
+        nullable: false
+      swe_normalized_counts_4:
+        db_column: swe_normalized_counts_4
+        type: integer
+        nullable: false
+      swe_normalized_counts_5:
+        db_column: swe_normalized_counts_5
+        type: integer
+        nullable: false
+      swe_normalized_counts_6:
+        db_column: swe_normalized_counts_6
+        type: integer
+        nullable: false
+      swe_normalized_counts_7:
+        db_column: swe_normalized_counts_7
+        type: integer
+        nullable: false
+      ttj2000ns:
+        db_column: ttj2000ns
+        type: bigint
+        nullable: false
+    filename_to_column:
+      template: imap_ialirt_swe_[date].csv
+      columns:
+        date:
+          db_column: file_date
+          type: date
+          use_to_delete_old_rows: true
+    indexes:
+    - name: idx_kernel_set_key
+      columns:
+      - column: kernel_set_key
+        order: DESC
+  imap_ialirt_swapi:
+    target_table: imap_ialirt_swapi
+    id_mapping:
+      time_utc:
+        db_column: id
+        type: datetime
+        nullable: false
+    columns:
+      instrument:
+        db_column: instrument
+        type: varchar(5)
+        nullable: false
+      kernel_set_key:
+        db_column: kernel_set_key
+        type: datetime
+        nullable: false
+      swapi_epoch:
+        db_column: swapi_epoch
+        type: bigint
+        nullable: false
+      swapi_pseudo_proton_density:
+        db_column: swapi_pseudo_proton_density
+        type: float
+        nullable: false
+      swapi_pseudo_proton_speed:
+        db_column: swapi_pseudo_proton_speed
+        type: float
+        nullable: false
+      swapi_pseudo_proton_temperature:
+        db_column: swapi_pseudo_proton_temperature
+        type: float
+        nullable: false
+      ttj2000ns:
+        db_column: ttj2000ns
+        type: bigint
+        nullable: false
+    filename_to_column:
+      template: imap_ialirt_swapi_[date].csv
+      columns:
+        date:
+          db_column: file_date
+          type: date
+          use_to_delete_old_rows: true
+    indexes:
+    - name: idx_kernel_set_key
+      columns:
+      - column: kernel_set_key
+        order: DESC
+  imap_ialirt_codice_hi:
+    target_table: imap_ialirt_codice_hi
+    id_mapping:
+      time_utc:
+        db_column: id
+        type: datetime
+        nullable: false
+    columns:
+      codice_hi_epoch_0:
+        db_column: codice_hi_epoch_0
+        type: bigint
+        nullable: false
+      codice_hi_epoch_1:
+        db_column: codice_hi_epoch_1
+        type: bigint
+        nullable: false
+      codice_hi_epoch_2:
+        db_column: codice_hi_epoch_2
+        type: bigint
+        nullable: false
+      codice_hi_epoch_3:
+        db_column: codice_hi_epoch_3
+        type: bigint
+        nullable: false
+      codice_hi_h_0:
+        db_column: codice_hi_h_0
+        type: text
+        nullable: false
+      codice_hi_h_1:
+        db_column: codice_hi_h_1
+        type: text
+        nullable: false
+      codice_hi_h_2:
+        db_column: codice_hi_h_2
+        type: text
+        nullable: false
+      codice_hi_h_3:
+        db_column: codice_hi_h_3
+        type: text
+        nullable: false
+      instrument:
+        db_column: instrument
+        type: varchar(9)
+        nullable: false
+      kernel_set_key:
+        db_column: kernel_set_key
+        type: datetime
+        nullable: false
+      ttj2000ns:
+        db_column: ttj2000ns
+        type: bigint
+        nullable: false
+    filename_to_column:
+      template: imap_ialirt_codice_hi_[date].csv
+      columns:
+        date:
+          db_column: file_date
+          type: date
+          use_to_delete_old_rows: true
+    indexes:
+    - name: idx_kernel_set_key
+      columns:
+      - column: kernel_set_key
+        order: DESC

--- a/src/imap_mag/cli/fetch/ialirt.py
+++ b/src/imap_mag/cli/fetch/ialirt.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from datetime import datetime
 from pathlib import Path
@@ -6,64 +7,76 @@ from typing import Annotated
 import typer
 
 from imap_mag.cli.cliUtils import initialiseLoggingForCommand
-from imap_mag.client.IALiRTApiClient import IALiRTApiClient
 from imap_mag.config import AppSettings, FetchMode
-from imap_mag.download.FetchIALiRT import FetchIALiRT
-from imap_mag.io import DatastoreFileManager, FileFinder
-from imap_mag.io.file import IALiRTHKPathHandler, IALiRTPathHandler
-from imap_mag.io.file.IFilePathHandler import IFilePathHandler
+from imap_mag.data_pipelines import AutomaticRunParameters, FetchByDatesRunParameters
+from imap_mag.data_pipelines.IALiRTInstrumentPipeline import IALiRTInstrumentPipeline
+from imap_mag.db import Database
+from imap_mag.util.constants import CONSTANTS
 
 logger = logging.getLogger(__name__)
 
-
-def _create_fetch_ialirt(app_settings: AppSettings) -> FetchIALiRT:
-    """Create a FetchIALiRT instance with common configuration."""
-
-    data_access = IALiRTApiClient(
-        app_settings.fetch_ialirt.api.auth_code,
-        app_settings.fetch_ialirt.api.url_base,
-    )
-    datastore_finder = FileFinder(app_settings.data_store)
-    work_folder = app_settings.setup_work_folder_for_command(app_settings.fetch_ialirt)
-
-    initialiseLoggingForCommand(
-        work_folder
-    )  # DO NOT log anything before this point (it won't be captured in the log file)
-
-    return FetchIALiRT(
-        data_access, work_folder, datastore_finder, app_settings.packet_definition
-    )
+# Instruments accepted by `fetch ialirt` (excludes mag_hk which has its own sub-command)
+_SCIENCE_INSTRUMENTS = [
+    k for k in CONSTANTS.DATABASE.IALIRT_INSTRUMENT_PROGRESS_IDS if k != "mag_hk"
+]
 
 
-def _publish_files(
-    app_settings: AppSettings,
-    downloaded_files: dict[Path, IFilePathHandler],
+def _run_pipeline(
+    instrument: str,
+    start_date: datetime | None,
+    end_date: datetime | None,
     fetch_mode: FetchMode,
-) -> dict[Path, IFilePathHandler]:
-    """Publish downloaded files to data store."""
+    app_settings: AppSettings,
+) -> list[Path]:
+    """Build and run an IALiRTInstrumentPipeline, returning the produced file paths."""
 
-    if not app_settings.fetch_ialirt.publish_to_data_store:
-        logger.info("Files not published to data store based on config.")
-        return downloaded_files
+    work_folder = app_settings.setup_work_folder_for_command(app_settings.fetch_ialirt)
+    initialiseLoggingForCommand(work_folder)
 
-    datastore_manager = DatastoreFileManager.CreateByMode(
-        app_settings,
-        use_database=(fetch_mode == FetchMode.DownloadAndUpdateProgress),
+    use_database = fetch_mode == FetchMode.DownloadAndUpdateProgress
+    database = Database() if use_database else None
+
+    pipeline = IALiRTInstrumentPipeline(
+        instrument=instrument,
+        database=database,
+        settings=app_settings,
     )
 
-    result: dict[Path, IFilePathHandler] = dict()
-    for file, path_handler in downloaded_files.items():
-        (output_file, output_handler) = datastore_manager.add_file(file, path_handler)
-        result[output_file] = output_handler
+    if start_date is not None:
+        run_params: AutomaticRunParameters | FetchByDatesRunParameters = (
+            FetchByDatesRunParameters(start_date=start_date, end_date=end_date)
+        )
+    else:
+        run_params = AutomaticRunParameters()
 
-    return result
+    pipeline.build(run_params)
+    asyncio.run(pipeline.run())
+    result = pipeline.get_results()
+
+    if not result.success:
+        raise RuntimeError(f"I-ALiRT {instrument} pipeline failed: {result}")
+
+    return [item.file_path for item in result.data_items if hasattr(item, "file_path")]
 
 
 # E.g.,
 # imap-mag fetch ialirt --start-date 2025-01-02 --end-date 2025-01-03
+# imap-mag fetch ialirt --instrument swe --start-date 2025-01-02 --end-date 2025-01-03
 def fetch_ialirt(
-    start_date: Annotated[datetime, typer.Option(help="Start date for the download")],
-    end_date: Annotated[datetime, typer.Option(help="End date for the download")],
+    start_date: Annotated[
+        datetime | None,
+        typer.Option(help="Start date for the download"),
+    ] = None,
+    end_date: Annotated[
+        datetime | None,
+        typer.Option(help="End date for the download"),
+    ] = None,
+    instrument: Annotated[
+        str,
+        typer.Option(
+            help=f"I-ALiRT instrument to download. Supported: {', '.join(_SCIENCE_INSTRUMENTS)}",
+        ),
+    ] = "mag",
     fetch_mode: Annotated[
         FetchMode,
         typer.Option(
@@ -71,33 +84,39 @@ def fetch_ialirt(
             help="Whether to download only or download and update progress in database",
         ),
     ] = FetchMode.DownloadOnly,
-) -> dict[Path, IALiRTPathHandler]:
-    """Download I-ALiRT MAG data from SDC."""
+) -> list[Path]:
+    """Download I-ALiRT data from the I-ALiRT API."""
+
+    if instrument not in _SCIENCE_INSTRUMENTS:
+        raise typer.BadParameter(
+            f"Unknown instrument '{instrument}'. Supported: {', '.join(_SCIENCE_INSTRUMENTS)}"
+        )
 
     app_settings = AppSettings()  # type: ignore
 
-    fetch = _create_fetch_ialirt(app_settings)
+    files = _run_pipeline(instrument, start_date, end_date, fetch_mode, app_settings)
 
-    downloaded_ialirt: dict[Path, IALiRTPathHandler] = fetch.download_mag_to_csv(
-        start_date=start_date,
-        end_date=end_date,
-    )
-
-    if not downloaded_ialirt:
-        logger.info(f"No I-ALiRT MAG data downloaded from {start_date} to {end_date}.")
+    if not files:
+        logger.info(f"No I-ALiRT {instrument} data downloaded.")
     else:
         logger.debug(
-            f"Downloaded {len(downloaded_ialirt)} files:\n{', '.join(str(f) for f in downloaded_ialirt.keys())}"
+            f"Downloaded {len(files)} files:\n{', '.join(str(f) for f in files)}"
         )
 
-    return _publish_files(app_settings, downloaded_ialirt, fetch_mode)
+    return files
 
 
 # E.g.,
 # imap-mag fetch ialirt-hk --start-date 2025-01-02 --end-date 2025-01-03
 def fetch_ialirt_hk(
-    start_date: Annotated[datetime, typer.Option(help="Start date for the download")],
-    end_date: Annotated[datetime, typer.Option(help="End date for the download")],
+    start_date: Annotated[
+        datetime | None,
+        typer.Option(help="Start date for the download"),
+    ] = None,
+    end_date: Annotated[
+        datetime | None,
+        typer.Option(help="End date for the download"),
+    ] = None,
     fetch_mode: Annotated[
         FetchMode,
         typer.Option(
@@ -105,27 +124,18 @@ def fetch_ialirt_hk(
             help="Whether to download only or download and update progress in database",
         ),
     ] = FetchMode.DownloadOnly,
-) -> dict[Path, IALiRTHKPathHandler]:
-    """Download I-ALiRT MAG HK data from SDC."""
+) -> list[Path]:
+    """Download I-ALiRT MAG HK data from the I-ALiRT API."""
 
     app_settings = AppSettings()  # type: ignore
 
-    fetch = _create_fetch_ialirt(app_settings)
+    files = _run_pipeline("mag_hk", start_date, end_date, fetch_mode, app_settings)
 
-    logger.info(f"Downloading I-ALiRT MAG HK from {start_date} to {end_date}.")
-
-    downloaded_hk: dict[Path, IALiRTHKPathHandler] = fetch.download_mag_hk_to_csv(
-        start_date=start_date,
-        end_date=end_date,
-    )
-
-    if not downloaded_hk:
-        logger.info(
-            f"No I-ALiRT MAG HK data downloaded from {start_date} to {end_date}."
-        )
+    if not files:
+        logger.info("No I-ALiRT MAG HK data downloaded.")
     else:
         logger.debug(
-            f"Downloaded {len(downloaded_hk)} files:\n{', '.join(str(f) for f in downloaded_hk.keys())}"
+            f"Downloaded {len(files)} files:\n{', '.join(str(f) for f in files)}"
         )
 
-    return _publish_files(app_settings, downloaded_hk, fetch_mode)
+    return files

--- a/src/imap_mag/data_pipelines/DownloadIALiRTStage.py
+++ b/src/imap_mag/data_pipelines/DownloadIALiRTStage.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+
+from imap_mag.data_pipelines import PROGRESS_DATE_CONTEXT_KEY, FileRecord, Record, Stage
+from imap_mag.download.FetchIALiRT import FetchIALiRT
+from imap_mag.io.file.IFilePathHandler import IFilePathHandler
+
+
+class DownloadIALiRTStage(Stage):
+    """Download I-ALiRT data for a specific instrument and emit one FileRecord per day."""
+
+    def __init__(self, instrument: str, fetcher: FetchIALiRT):
+        super().__init__()
+        self.instrument = instrument
+        self.fetcher = fetcher
+
+    async def process(self, item: Record, context: dict, **kwargs):
+        if not item or not item.start_date or not item.end_date:
+            raise ValueError(
+                "DownloadIALiRTStage requires a Record with start_date and end_date"
+            )
+
+        start_date = item.start_date
+        end_date = item.end_date
+
+        self.logger.info(
+            f"Downloading I-ALiRT {self.instrument} data from {start_date} to {end_date}."
+        )
+
+        downloaded: dict[Path, IFilePathHandler] = (
+            self.fetcher.download_instrument_to_csv(
+                instrument=self.instrument,
+                start_date=start_date,
+                end_date=end_date,
+            )
+        )
+
+        if not downloaded:
+            self.logger.info(
+                f"No I-ALiRT {self.instrument} data downloaded from {start_date} to {end_date}."
+            )
+            return
+
+        for file_path, path_handler in downloaded.items():
+            content_date = path_handler.get_content_date_for_indexing()
+
+            if content_date and (
+                context.get(PROGRESS_DATE_CONTEXT_KEY) is None
+                or content_date > context[PROGRESS_DATE_CONTEXT_KEY]
+            ):
+                context[PROGRESS_DATE_CONTEXT_KEY] = content_date
+
+            await self.publish_next(
+                FileRecord(file_path, content_date), context, **kwargs
+            )

--- a/src/imap_mag/data_pipelines/IALiRTInstrumentPipeline.py
+++ b/src/imap_mag/data_pipelines/IALiRTInstrumentPipeline.py
@@ -1,0 +1,78 @@
+from imap_mag.client.IALiRTApiClient import IALiRTApiClient
+from imap_mag.config.AppSettings import AppSettings
+from imap_mag.data_pipelines import (
+    AutomaticRunParameters,
+    FetchByDatesRunParameters,
+    Pipeline,
+)
+from imap_mag.data_pipelines.DownloadIALiRTStage import DownloadIALiRTStage
+from imap_mag.data_pipelines.GetProcessingDatesStage import (
+    DateResolutionMode,
+    GetProcessingDatesStage,
+)
+from imap_mag.data_pipelines.PublishFileToDatastoreStage import (
+    PublishFileToDatastoreStage,
+)
+from imap_mag.data_pipelines.SaveProcessingDatesStage import SaveProcessingDatesStage
+from imap_mag.db import Database
+from imap_mag.download.FetchIALiRT import FetchIALiRT
+from imap_mag.io import FileFinder
+from imap_mag.util.constants import CONSTANTS
+
+
+class IALiRTInstrumentPipeline(Pipeline):
+    """Pipeline that downloads I-ALiRT data for a single instrument."""
+
+    def __init__(
+        self,
+        instrument: str,
+        database: Database | None,
+        settings: AppSettings,
+    ):
+        super().__init__(settings=settings)
+
+        if instrument not in CONSTANTS.DATABASE.IALIRT_INSTRUMENT_PROGRESS_IDS:
+            raise ValueError(
+                f"Unknown I-ALiRT instrument '{instrument}'. "
+                f"Supported: {list(CONSTANTS.DATABASE.IALIRT_INSTRUMENT_PROGRESS_IDS.keys())}"
+            )
+
+        self._instrument = instrument
+        self._database = database
+
+        progress_item_name = CONSTANTS.DATABASE.IALIRT_INSTRUMENT_PROGRESS_IDS[
+            instrument
+        ]
+        self.initial_context = {"progress_item_name": progress_item_name}
+
+        data_access = IALiRTApiClient(
+            settings.fetch_ialirt.api.auth_code,
+            settings.fetch_ialirt.api.url_base,
+        )
+        work_folder = settings.setup_work_folder_for_command(settings.fetch_ialirt)
+        datastore_finder = FileFinder(settings.data_store)
+
+        self._fetcher = FetchIALiRT(
+            data_access, work_folder, datastore_finder, settings.packet_definition
+        )
+
+    def build(self, run_params: AutomaticRunParameters | FetchByDatesRunParameters):
+        super().build(
+            run_parameters=run_params,
+            stages=[
+                GetProcessingDatesStage(
+                    database=self._database,
+                    date_resolution_mode=DateResolutionMode.EXACT_DATETIME,
+                ),
+                DownloadIALiRTStage(
+                    instrument=self._instrument,
+                    fetcher=self._fetcher,
+                ),
+                PublishFileToDatastoreStage(
+                    enabled=self._settings.fetch_ialirt.publish_to_data_store,
+                    database=self._database,
+                    settings=self._settings,
+                ),
+                SaveProcessingDatesStage(database=self._database),
+            ],
+        )

--- a/src/imap_mag/download/FetchIALiRT.py
+++ b/src/imap_mag/download/FetchIALiRT.py
@@ -10,6 +10,7 @@ import yaml
 from imap_mag.client.IALiRTApiClient import IALiRTApiClient
 from imap_mag.io import FileFinder
 from imap_mag.io.file import IALiRTHKPathHandler, IALiRTPathHandler
+from imap_mag.io.file.IALiRTInstrumentPathHandler import IALiRTInstrumentPathHandler
 from imap_mag.io.file.IFilePathHandler import IFilePathHandler
 from imap_mag.process import get_packet_definition_folder
 from imap_mag.util.constants import CONSTANTS
@@ -44,7 +45,7 @@ class FetchIALiRT:
     ) -> dict[Path, IALiRTPathHandler]:
         """Retrieve I-ALiRT MAG science data."""
 
-        return self.__download_to_csv(
+        return self.download_to_csv(
             instrument="mag",
             start_date=start_date,
             end_date=end_date,
@@ -62,7 +63,7 @@ class FetchIALiRT:
     ) -> dict[Path, IALiRTHKPathHandler]:
         """Retrieve I-ALiRT MAG HK data."""
 
-        return self.__download_to_csv(
+        return self.download_to_csv(
             instrument="mag_hk",
             start_date=start_date,
             end_date=end_date,
@@ -73,10 +74,33 @@ class FetchIALiRT:
                 df,
                 self.__packetDefinitionFolder / self.__IALIRT_PACKET_DEFINITION_FILE,
             ),
-            max_hours_per_chunk=2,  # Limit to 3 hours per chunk to avoid 400 error
+            max_hours_per_chunk=2,  # Limit to 2 hours per chunk to avoid 400 error
         )
 
-    def __download_to_csv(
+    def download_instrument_to_csv(
+        self,
+        instrument: str,
+        start_date: datetime,
+        end_date: datetime,
+    ) -> dict[Path, IFilePathHandler]:
+        """Retrieve I-ALiRT data for any instrument, dispatching to the right handler/processor."""
+
+        if instrument == "mag":
+            return self.download_mag_to_csv(start_date, end_date)
+        elif instrument == "mag_hk":
+            return self.download_mag_hk_to_csv(start_date, end_date)
+        else:
+            return self.download_to_csv(
+                instrument=instrument,
+                start_date=start_date,
+                end_date=end_date,
+                path_handler_factory=lambda content_date: IALiRTInstrumentPathHandler(
+                    instrument=instrument, content_date=content_date
+                ),
+                process_fn=process_ialirt_default,
+            )
+
+    def download_to_csv(
         self,
         instrument: str,
         start_date: datetime,
@@ -286,3 +310,51 @@ def process_ialirt_hk_data(
                     )
 
     return df
+
+
+def process_ialirt_default(df: pd.DataFrame) -> pd.DataFrame:
+    """Process I-ALiRT data for instruments without a specific processor.
+
+    Flattens list columns (into _x/_y/_z for 3-element, else _0/_1/...) and
+    dict columns (into <col>.<key>) so the result is a flat CSV-friendly dataframe.
+    """
+
+    df.columns = df.columns.str.strip()
+
+    for column in list(df.columns):
+        non_null = df[df[column].notna()][column]
+        if non_null.empty:
+            continue
+
+        first_val = non_null.iloc[0]
+
+        if isinstance(first_val, list):
+            length = len(first_val)
+            if length == 3:
+                suffixes = ["x", "y", "z"]
+            else:
+                suffixes = [str(i) for i in range(length)]
+
+            for i, suffix in enumerate(suffixes):
+                df[f"{column}_{suffix}"] = non_null.apply(
+                    lambda x, idx=i: (
+                        x[idx] if isinstance(x, list) and len(x) > idx else None
+                    )
+                )
+            df = df.drop(columns=[column])
+
+        elif isinstance(first_val, dict):
+            flattened = pd.json_normalize(df[column].dropna())
+            flattened.columns = [f"{column}.{key}" for key in flattened.columns]
+            flattened.index = df[df[column].notna()].index
+            df = pd.concat([df.drop(columns=[column]), flattened], axis=1)
+
+    return df
+
+
+# Registry mapping instrument name to its processing function.
+# Unknown instruments fall back to process_ialirt_default.
+INSTRUMENT_PROCESSORS = {
+    "mag": process_ialirt_mag_data,
+    "mag_hk": process_ialirt_hk_data,
+}

--- a/src/imap_mag/io/FilePathHandlerSelector.py
+++ b/src/imap_mag/io/FilePathHandlerSelector.py
@@ -8,6 +8,8 @@ from imap_mag.io.file.CalibrationLayerPathHandler import (
 )
 from imap_mag.io.file.HKBinaryPathHandler import HKBinaryPathHandler
 from imap_mag.io.file.HKDecodedPathHandler import HKDecodedPathHandler
+from imap_mag.io.file.IALiRTHKPathHandler import IALiRTHKPathHandler
+from imap_mag.io.file.IALiRTInstrumentPathHandler import IALiRTInstrumentPathHandler
 from imap_mag.io.file.IALiRTPathHandler import IALiRTPathHandler
 from imap_mag.io.file.IFilePathHandler import IFilePathHandler
 from imap_mag.io.file.SciencePathHandler import SciencePathHandler
@@ -48,12 +50,16 @@ class FilePathHandlerSelector:
     ) -> IFilePathHandler | None:
         """Find a suitable path handler for the given filepath."""
 
-        # Providers to try in alphabetical order.
+        # Providers to try in order. More specific handlers first to prevent shadowing.
+        # IALiRTHKPathHandler before IALiRTInstrumentPathHandler before IALiRTPathHandler
+        # because the instrument handler would otherwise match hk_ files.
         provider_to_try: list[type[IFilePathHandler]] = [
             AncillaryPathHandler,
             CalibrationLayerPathHandler,
             HKBinaryPathHandler,
             HKDecodedPathHandler,
+            IALiRTHKPathHandler,
+            IALiRTInstrumentPathHandler,
             IALiRTPathHandler,
             SciencePathHandler,
             SpinTablePathHandler,

--- a/src/imap_mag/io/file/IALiRTInstrumentPathHandler.py
+++ b/src/imap_mag/io/file/IALiRTInstrumentPathHandler.py
@@ -1,0 +1,72 @@
+import logging
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+from imap_mag.io.file.IFilePathHandler import IFilePathHandler
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class IALiRTInstrumentPathHandler(IFilePathHandler):
+    """
+    Path handler for I-ALiRT instrument files (non-MAG, non-HK).
+
+    Produces files of the form:
+        ialirt/YYYY/MM/imap_ialirt_<instrument>_YYYYMMDD.csv
+    """
+
+    root_folder: str = "ialirt"
+
+    mission: str = "imap"
+    instrument: str = ""
+    content_date: datetime | None = None
+    extension: str = "csv"
+
+    def supports_sequencing(self) -> bool:
+        return False
+
+    def get_content_date_for_indexing(self) -> datetime | None:
+        return self.content_date
+
+    def get_folder_structure(self) -> str:
+        super()._check_property_values("folder structure", ["content_date"])
+        assert self.content_date
+
+        return (Path(self.root_folder) / self.content_date.strftime("%Y/%m")).as_posix()
+
+    def get_filename(self) -> str:
+        super()._check_property_values("file name", ["content_date", "instrument"])
+        assert self.content_date
+        assert self.instrument
+
+        return f"{self.mission}_ialirt_{self.instrument}_{self.content_date.strftime('%Y%m%d')}.{self.extension}"
+
+    def add_metadata(self, metadata: dict) -> None:
+        raise NotImplementedError()
+
+    def get_metadata(self) -> dict | None:
+        return None
+
+    @classmethod
+    def from_filename(
+        cls, filename: str | Path
+    ) -> "IALiRTInstrumentPathHandler | None":
+        match = re.match(
+            r"imap_ialirt_(?P<instrument>[a-z][a-z0-9_]+)_(?P<date>\d{8})\.(?P<ext>\w+)",
+            Path(filename).name,
+        )
+        logger.debug(
+            f"Filename {filename} matches {match.groupdict(0) if match else 'nothing'} with instrument regex."
+        )
+
+        if match is None:
+            return None
+        else:
+            return cls(
+                instrument=match["instrument"],
+                content_date=datetime.strptime(match["date"], "%Y%m%d"),
+                extension=match["ext"],
+            )

--- a/src/imap_mag/io/file/__init__.py
+++ b/src/imap_mag/io/file/__init__.py
@@ -5,6 +5,7 @@ from imap_mag.io.file.CalibrationLayerPathHandler import (
 from imap_mag.io.file.HKBinaryPathHandler import HKBinaryPathHandler
 from imap_mag.io.file.HKDecodedPathHandler import HKDecodedPathHandler
 from imap_mag.io.file.IALiRTHKPathHandler import IALiRTHKPathHandler
+from imap_mag.io.file.IALiRTInstrumentPathHandler import IALiRTInstrumentPathHandler
 from imap_mag.io.file.IALiRTPathHandler import IALiRTPathHandler
 from imap_mag.io.file.IALiRTQuicklookPathHandler import IALiRTQuicklookPathHandler
 from imap_mag.io.file.IFilePathHandler import IFilePathHandler, T
@@ -25,6 +26,7 @@ __all__ = [
     "HKBinaryPathHandler",
     "HKDecodedPathHandler",
     "IALiRTHKPathHandler",
+    "IALiRTInstrumentPathHandler",
     "IALiRTPathHandler",
     "IALiRTQuicklookPathHandler",
     "IFilePathHandler",

--- a/src/imap_mag/util/constants.py
+++ b/src/imap_mag/util/constants.py
@@ -1,4 +1,5 @@
 from datetime import UTC, datetime
+from typing import ClassVar
 
 import numpy as np
 
@@ -30,3 +31,13 @@ class CONSTANTS:
         IALIRT_PROGRESS_ID = "MAG_IALIRT"
         IALIRT_HK_PROGRESS_ID = "MAG_IALIRT_HK"
         IALIRT_VALIDATION_ID = "IALIRT_VALIDATION"
+
+        IALIRT_INSTRUMENT_PROGRESS_IDS: ClassVar[dict[str, str]] = {
+            "mag": IALIRT_PROGRESS_ID,
+            "mag_hk": IALIRT_HK_PROGRESS_ID,
+            "hit": "IALIRT_HIT",
+            "swe": "IALIRT_SWE",
+            "swapi": "IALIRT_SWAPI",
+            "codice_lo": "IALIRT_CODICE_LO",
+            "codice_hi": "IALIRT_CODICE_HI",
+        }

--- a/src/prefect_server/pollIALiRT.py
+++ b/src/prefect_server/pollIALiRT.py
@@ -4,21 +4,23 @@ from pathlib import Path
 from typing import Annotated
 
 import pytz
-from prefect import flow
+from prefect import flow, task
 from prefect.blocks.notifications import MicrosoftTeamsWebhook
 from prefect.events import Event, emit_event
 from prefect.runtime import flow_run
 from pydantic import Field
 
-from imap_mag.cli.fetch.DownloadDateManager import DownloadDateManager
-from imap_mag.cli.fetch.ialirt import fetch_ialirt, fetch_ialirt_hk
-from imap_mag.config.FetchMode import FetchMode
-from imap_mag.db import Database, update_database_with_progress
-from imap_mag.io.file.IFilePathHandler import IFilePathHandler
+from imap_mag.config.AppSettings import AppSettings
+from imap_mag.data_pipelines import FetchByDatesRunParameters
+from imap_mag.data_pipelines.IALiRTInstrumentPipeline import IALiRTInstrumentPipeline
+from imap_mag.data_pipelines.Result import Result
+from imap_mag.db import Database
 from imap_mag.util import CONSTANTS, DatetimeProvider, Environment
 from prefect_server.constants import PREFECT_CONSTANTS
 from prefect_server.prefectUtils import get_secret_or_env_var, try_get_prefect_logger
 from prefect_server.quicklookIALiRT import quicklook_ialirt_flow
+
+_ALL_INSTRUMENTS = list(CONSTANTS.DATABASE.IALIRT_INSTRUMENT_PROGRESS_IDS.keys())
 
 
 def generate_flow_run_name() -> str:
@@ -35,26 +37,40 @@ def generate_flow_run_name() -> str:
         else DatetimeProvider.end_of_hour()
     )
 
-    return f"Poll-IALiRT-from-{start_date}-to-{end_date.strftime('%d-%m-%YT%H:%M:%S')}"
-
-
-def generate_hk_flow_run_name() -> str:
-    parameters = flow_run.parameters
-
-    start_date: str = (
-        parameters["start_date"].strftime("%d-%m-%YT%H:%M:%S")
-        if parameters["start_date"]
-        else "last-update"
-    )
-    end_date: datetime = (
-        parameters["end_date"]
-        if parameters["end_date"]
-        else DatetimeProvider.end_of_hour()
-    )
-
     return (
-        f"Poll-IALiRT-HK-from-{start_date}-to-{end_date.strftime('%d-%m-%YT%H:%M:%S')}"
+        f"Poll-IALiRT-All-from-{start_date}-to-{end_date.strftime('%d-%m-%YT%H:%M:%S')}"
     )
+
+
+@task(name="poll-ialirt-instrument")
+async def poll_instrument_task(
+    instrument: str,
+    start_date: datetime | None,
+    end_date: datetime | None,
+    force_download: bool,
+    auth_code: str,
+) -> Result:
+    """Download the latest data for a single I-ALiRT instrument."""
+
+    with Environment(CONSTANTS.ENV_VAR_NAMES.IALIRT_AUTH_CODE, auth_code):
+        settings = AppSettings()  # type: ignore
+        database = Database()
+
+        pipeline = IALiRTInstrumentPipeline(
+            instrument=instrument,
+            database=database,
+            settings=settings,
+        )
+
+        run_params = FetchByDatesRunParameters(
+            start_date=start_date,  # None = use DB progress as start
+            end_date=end_date,
+            force_redownload=force_download,
+        )
+
+        pipeline.build(run_params)
+        await pipeline.run()
+        return pipeline.get_results()
 
 
 @flow(
@@ -114,7 +130,7 @@ async def poll_ialirt_flow(
         Field(
             json_schema_extra={
                 "title": "Plot last 3 days",
-                "description": "If true, the flow will generate a quicklook plot of the downloaded data over the last 3 days.",
+                "description": "If true, the flow will generate a quicklook plot of the downloaded MAG data over the last 3 days.",
             }
         ),
     ] = True,
@@ -130,39 +146,82 @@ async def poll_ialirt_flow(
     ] = PREFECT_CONSTANTS.IMAP_WEBHOOK_BLOCK_NAME,
 ) -> None:
     """
-    Poll I-ALiRT MAG data from SDC.
+    Poll all I-ALiRT instruments from the I-ALiRT API.
+
+    Runs one Prefect task per instrument per polling tick so each instrument's
+    progress and logs are tracked independently.
     """
 
     logger = try_get_prefect_logger(__name__)
-    database = Database()
 
     auth_code = await get_secret_or_env_var(
         PREFECT_CONSTANTS.POLL_IALIRT.IALIRT_AUTH_CODE_SECRET_NAME,
         CONSTANTS.ENV_VAR_NAMES.IALIRT_AUTH_CODE,
     )
-    end_date = end_date or DatetimeProvider.end_of_hour()
-    updated_files: list[Path] = []
+    end = end_date or DatetimeProvider.end_of_hour()
 
-    logger.info("---------- Start I-ALiRT MAG Poll ----------")
+    logger.info(
+        f"---------- Start I-ALiRT All Instruments Poll (instruments: {_ALL_INSTRUMENTS}) ----------"
+    )
+
+    # Accumulate mag_hk file paths across all ticks for event emission
+    mag_hk_downloaded_files: list[Path] = []
+
+    async def run_one_tick() -> None:
+        results: list[Result] = await asyncio.gather(
+            *[
+                poll_instrument_task(
+                    instrument=instrument,
+                    start_date=start_date,
+                    end_date=end,
+                    force_download=force_download,
+                    auth_code=auth_code,
+                )
+                for instrument in _ALL_INSTRUMENTS
+            ],
+            return_exceptions=True,
+        )
+
+        for instrument, result in zip(_ALL_INSTRUMENTS, results):
+            if isinstance(result, Exception):
+                logger.error(f"Task for instrument '{instrument}' failed: {result}")
+                continue
+
+            if instrument == "mag_hk" and result.success and result.data_items:
+                mag_hk_downloaded_files.extend(
+                    item.file_path
+                    for item in result.data_items
+                    if hasattr(item, "file_path")
+                )
 
     if wait_for_new_data_to_arrive:
-        while (end_date - DatetimeProvider.now()).total_seconds() > timeout:
-            files = do_poll_ialirt(
-                database, auth_code, start_date, end_date, force_download, logger
-            )
-            updated_files.extend(files)
-
+        while (end - DatetimeProvider.now()).total_seconds() > timeout:
+            await run_one_tick()
             logger.info(
                 f"--- Waiting {timeout} seconds before polling for new data ---"
             )
             await asyncio.sleep(timeout)
     else:
-        files = do_poll_ialirt(
-            database, auth_code, start_date, end_date, force_download, logger
-        )
-        updated_files.extend(files)
+        await run_one_tick()
 
-    logger.info("---------- End I-ALiRT MAG Poll ----------")
+    logger.info("---------- End I-ALiRT All Instruments Poll ----------")
+
+    # Emit event so downstream flows (e.g. check_ialirt) know HK data was updated
+    if mag_hk_downloaded_files:
+        logger.debug(f"Emitting {PREFECT_CONSTANTS.EVENT.IALIRT_HK_UPDATED} event")
+        event: Event | None = emit_event(
+            event=PREFECT_CONSTANTS.EVENT.IALIRT_HK_UPDATED,
+            resource={
+                "prefect.resource.id": f"prefect.flow-run.{flow_run.id}",
+                "prefect.resource.name": flow_run.name,
+                "prefect.resource.role": "flow-run",
+            },
+            payload={"files": [str(f) for f in mag_hk_downloaded_files]},
+        )
+        if event is None:
+            logger.error(
+                f"Failed to emit {PREFECT_CONSTANTS.EVENT.IALIRT_HK_UPDATED} event"
+            )
 
     if plot_last_3_days:
         await quicklook_ialirt_flow(
@@ -172,15 +231,14 @@ async def poll_ialirt_flow(
         )
 
         # If this is the 6 AM (UK time) polling job, send the latest figure to Teams
-        uk_end_time = end_date.replace(tzinfo=UTC).astimezone(
-            pytz.timezone("Europe/London")
-        )
+        uk_end_time = end.replace(tzinfo=UTC).astimezone(pytz.timezone("Europe/London"))
 
         if wait_for_new_data_to_arrive and (uk_end_time.hour == 6):
             imap_webhook_block = await MicrosoftTeamsWebhook.aload(
                 imap_notification_webhook_name
             )
 
+            database = Database()
             latest_ialirt_date = database.get_workflow_progress(
                 CONSTANTS.DATABASE.IALIRT_PROGRESS_ID
             )
@@ -194,218 +252,3 @@ async def poll_ialirt_flow(
                 body=message_body,
                 subject="I-ALiRT Latest Quicklook",
             )  # type: ignore
-
-
-@flow(
-    name=PREFECT_CONSTANTS.FLOW_NAMES.POLL_IALIRT_HK,
-    log_prints=True,
-    flow_run_name=generate_hk_flow_run_name,
-    retries=1,
-)
-async def poll_ialirt_hk_flow(
-    start_date: Annotated[
-        datetime | None,
-        Field(
-            json_schema_extra={
-                "title": "Start date",
-                "description": "Start date for the download. Default is the last update.",
-            }
-        ),
-    ] = None,
-    end_date: Annotated[
-        datetime | None,
-        Field(
-            json_schema_extra={
-                "title": "End date",
-                "description": "End date for the download. Default is the end of the hour.",
-            }
-        ),
-    ] = None,
-    force_download: Annotated[
-        bool,
-        Field(
-            json_schema_extra={
-                "title": "Force download",
-                "description": "If true, the flow will download data even if it has already been downloaded before.",
-            }
-        ),
-    ] = False,
-    wait_for_new_data_to_arrive: Annotated[
-        bool,
-        Field(
-            json_schema_extra={
-                "title": "Wait for new data to arrive",
-                "description": "If true, the flow will poll for new data until the end date is reached.",
-            }
-        ),
-    ] = True,
-    timeout: Annotated[
-        int,
-        Field(
-            json_schema_extra={
-                "title": "Timeout",
-                "description": "Time in seconds to wait between polling for new data. Only used when waiting for new data.",
-            }
-        ),
-    ] = 5 * 60,  # 5 minutes
-) -> None:
-    """
-    Poll I-ALiRT MAG HK data from SDC.
-    """
-
-    logger = try_get_prefect_logger(__name__)
-    database = Database()
-
-    auth_code = await get_secret_or_env_var(
-        PREFECT_CONSTANTS.POLL_IALIRT.IALIRT_AUTH_CODE_SECRET_NAME,
-        CONSTANTS.ENV_VAR_NAMES.IALIRT_AUTH_CODE,
-    )
-    end_date = end_date or DatetimeProvider.end_of_hour()
-    updated_files: list[Path] = []
-
-    logger.info("---------- Start I-ALiRT MAG HK Poll ----------")
-
-    if wait_for_new_data_to_arrive:
-        while (end_date - DatetimeProvider.now()).total_seconds() > timeout:
-            files = do_poll_ialirt_hk(
-                database, auth_code, start_date, end_date, force_download, logger
-            )
-            updated_files.extend(files)
-
-            logger.info(
-                f"--- Waiting {timeout} seconds before polling for new data ---"
-            )
-            await asyncio.sleep(timeout)
-    else:
-        files = do_poll_ialirt_hk(
-            database, auth_code, start_date, end_date, force_download, logger
-        )
-        updated_files.extend(files)
-
-    logger.info("---------- End I-ALiRT MAG HK Poll ----------")
-
-
-def do_poll_ialirt(
-    database: Database,
-    auth_code: str,
-    start_date: datetime | None,
-    end_date: datetime | None,
-    force_download: bool,
-    logger,
-) -> list[Path]:
-    return _do_poll(
-        database=database,
-        auth_code=auth_code,
-        start_date=start_date,
-        end_date=end_date,
-        force_download=force_download,
-        logger=logger,
-        progress_item_id=CONSTANTS.DATABASE.IALIRT_PROGRESS_ID,
-        fetch_fn=fetch_ialirt,
-        event_type=None,
-    )
-
-
-def do_poll_ialirt_hk(
-    database: Database,
-    auth_code: str,
-    start_date: datetime | None,
-    end_date: datetime | None,
-    force_download: bool,
-    logger,
-) -> list[Path]:
-    return _do_poll(
-        database=database,
-        auth_code=auth_code,
-        start_date=start_date,
-        end_date=end_date,
-        force_download=force_download,
-        logger=logger,
-        progress_item_id=CONSTANTS.DATABASE.IALIRT_HK_PROGRESS_ID,
-        fetch_fn=fetch_ialirt_hk,
-        event_type=PREFECT_CONSTANTS.EVENT.IALIRT_HK_UPDATED,
-    )
-
-
-def _do_poll(
-    database: Database,
-    auth_code: str,
-    start_date: datetime | None,
-    end_date: datetime | None,
-    force_download: bool,
-    logger,
-    progress_item_id: str,
-    fetch_fn,
-    event_type: str | None,
-) -> list[Path]:
-    start_timestamp = DatetimeProvider.now()
-
-    date_manager = DownloadDateManager(
-        progress_item_id,
-        database,
-        earliest_date=DatetimeProvider.yesterday(),
-        progress_time_buffer=timedelta(
-            seconds=1  # do not download the last packet again
-        ),
-    )
-
-    packet_dates = date_manager.get_dates_for_download(
-        original_start_date=start_date,
-        original_end_date=end_date,
-        validate_with_database=(not force_download),
-    )
-
-    if packet_dates is None:
-        logger.info("No dates to download - skipping")
-        return []
-    else:
-        (packet_start_date, packet_end_date) = packet_dates
-
-    # Download files from SDC
-    with Environment(CONSTANTS.ENV_VAR_NAMES.IALIRT_AUTH_CODE, auth_code):
-        downloaded: dict[Path, IFilePathHandler] = fetch_fn(
-            start_date=packet_start_date,
-            end_date=packet_end_date,
-            fetch_mode=FetchMode.DownloadAndUpdateProgress,
-        )
-
-    if not downloaded:
-        logger.info(
-            f"No I-ALiRT data downloaded from {packet_start_date} to {packet_end_date}."
-        )
-        return []
-
-    # Update database with latest downloaded date as progress
-    content_dates: list[datetime] = [
-        metadata.content_date
-        for metadata in downloaded.values()
-        if metadata.content_date
-    ]
-    latest_date: datetime | None = max(content_dates) if content_dates else None
-
-    update_database_with_progress(
-        progress_item_id=progress_item_id,
-        database=database,
-        checked_timestamp=start_timestamp,
-        latest_timestamp=latest_date,
-    )
-
-    # Trigger event to notify updated I-ALiRT data
-    if event_type is not None:
-        logger.debug(f"Emitting {event_type} event")
-
-        event: Event | None = emit_event(
-            event=event_type,
-            resource={
-                "prefect.resource.id": f"prefect.flow-run.{flow_run.id}",
-                "prefect.resource.name": flow_run.name,
-                "prefect.resource.role": "flow-run",
-            },
-            payload={"files": list(downloaded.keys())},
-        )
-        if event is None:
-            logger.error(f"Failed to emit {event_type} event")
-    else:
-        event = None
-
-    return list(downloaded.keys())

--- a/src/prefect_server/workflow.py
+++ b/src/prefect_server/workflow.py
@@ -22,7 +22,7 @@ from prefect_server.performCalibration import (
     gradiometry_flow,
 )
 from prefect_server.pollHK import poll_hk_flow
-from prefect_server.pollIALiRT import poll_ialirt_flow, poll_ialirt_hk_flow
+from prefect_server.pollIALiRT import poll_ialirt_flow
 from prefect_server.pollLoPivotPlatform import poll_lo_pivot_platform_flow
 from prefect_server.pollScience import poll_science_flow
 from prefect_server.pollSpice import poll_spice_flow
@@ -123,13 +123,6 @@ async def adeploy_flows(local_debug: bool = False):
         concurrency_limit=ConcurrencyLimitConfig(
             limit=1, collision_strategy=ConcurrencyLimitStrategy.CANCEL_NEW
         ),
-    )
-
-    poll_ialirt_hk_deployable = poll_ialirt_hk_flow.to_deployment(
-        name=PREFECT_CONSTANTS.DEPLOYMENT_NAMES.POLL_IALIRT_HK,
-        cron=get_cron_from_env(PREFECT_CONSTANTS.ENV_VAR_NAMES.POLL_IALIRT_HK_CRON),
-        job_variables=shared_job_variables,
-        tags=[PREFECT_CONSTANTS.PREFECT_TAG],
     )
 
     poll_hk_deployable = poll_hk_flow.to_deployment(
@@ -301,13 +294,6 @@ async def adeploy_flows(local_debug: bool = False):
                 },
             ),
             DeploymentEventTrigger(
-                name="Trigger upload after I-ALiRT HK poll",
-                expect={PREFECT_CONSTANTS.EVENT.FLOW_RUN_COMPLETED},
-                match_related={
-                    "prefect.resource.name": PREFECT_CONSTANTS.FLOW_NAMES.POLL_IALIRT_HK
-                },
-            ),
-            DeploymentEventTrigger(
                 name="Trigger upload after science poll",
                 expect={PREFECT_CONSTANTS.EVENT.FLOW_RUN_COMPLETED},
                 match_related={
@@ -410,7 +396,6 @@ async def adeploy_flows(local_debug: bool = False):
 
     deployables = await asyncio.gather(
         poll_ialirt_deployable,
-        poll_ialirt_hk_deployable,
         poll_hk_deployable,
         poll_spice_deployable,
         poll_science_deployable,

--- a/tests/test_fetchIALiRT.py
+++ b/tests/test_fetchIALiRT.py
@@ -13,6 +13,7 @@ import pytest
 from imap_mag.client.IALiRTApiClient import IALiRTApiClient
 from imap_mag.download.FetchIALiRT import (
     FetchIALiRT,
+    process_ialirt_default,
     process_ialirt_hk_data,
     process_ialirt_mag_data,
 )
@@ -721,3 +722,121 @@ def test_process_mag_data_with_vectors() -> None:
     assert processed_df.at[1, "mag_B_RTN_r"] == 10
     assert processed_df.at[1, "mag_B_RTN_t"] == 11
     assert processed_df.at[1, "mag_B_RTN_n"] == 12
+
+
+def test_process_ialirt_default_scalar_passthrough() -> None:
+    raw_data = [
+        {"time_utc": "2026-05-01T00:00:00", "flux": 1.5, "energy": 3.2},
+        {"time_utc": "2026-05-01T01:00:00", "flux": 2.0, "energy": 4.1},
+    ]
+    df = pd.DataFrame(raw_data)
+
+    processed = process_ialirt_default(df)
+
+    assert list(processed.columns) == ["time_utc", "flux", "energy"]
+    assert processed.at[0, "flux"] == 1.5
+    assert processed.at[1, "energy"] == 4.1
+
+
+def test_process_ialirt_default_3element_list_uses_xyz() -> None:
+    raw_data = [
+        {"time_utc": "2026-05-01T00:00:00", "vec": [1, 2, 3]},
+    ]
+    df = pd.DataFrame(raw_data)
+
+    processed = process_ialirt_default(df)
+
+    assert "vec" not in processed.columns
+    assert processed.at[0, "vec_x"] == 1
+    assert processed.at[0, "vec_y"] == 2
+    assert processed.at[0, "vec_z"] == 3
+
+
+def test_process_ialirt_default_2element_list_uses_indexed() -> None:
+    raw_data = [
+        {"time_utc": "2026-05-01T00:00:00", "pair": [10, 20]},
+    ]
+    df = pd.DataFrame(raw_data)
+
+    processed = process_ialirt_default(df)
+
+    assert "pair" not in processed.columns
+    assert processed.at[0, "pair_0"] == 10
+    assert processed.at[0, "pair_1"] == 20
+
+
+def test_process_ialirt_default_dict_column_flattened() -> None:
+    raw_data = [
+        {"time_utc": "2026-05-01T00:00:00", "status": {"temp": 42, "mode": 3}},
+    ]
+    df = pd.DataFrame(raw_data)
+
+    processed = process_ialirt_default(df)
+
+    assert "status" not in processed.columns
+    assert processed.at[0, "status.temp"] == 42
+    assert processed.at[0, "status.mode"] == 3
+
+
+def test_fetch_ialirt_download_instrument_to_csv_uses_instrument_path_handler(
+    mock_ialirt_data_access: mock.Mock,
+    temp_datastore,  # noqa: F811
+) -> None:
+    from imap_mag.io.file.IALiRTInstrumentPathHandler import IALiRTInstrumentPathHandler
+
+    fetch = FetchIALiRT(
+        mock_ialirt_data_access,
+        Path(tempfile.mkdtemp()),
+        FileFinder(temp_datastore),
+        IALIRT_PACKET_DEFINITION,
+    )
+
+    mock_ialirt_data_access.get_all_by_dates.side_effect = lambda **_: [
+        {"time_utc": "2026-05-01T00:00:00", "flux": 1.5},
+    ]
+
+    result = fetch.download_instrument_to_csv(
+        instrument="swe",
+        start_date=datetime(2026, 5, 1),
+        end_date=datetime(2026, 5, 2),
+    )
+
+    assert len(result) == 1
+    path_handler = next(iter(result.values()))
+    assert isinstance(path_handler, IALiRTInstrumentPathHandler)
+    assert path_handler.instrument == "swe"
+
+    file_path = next(iter(result.keys()))
+    assert "imap_ialirt_swe_" in file_path.name
+
+
+def test_fetch_ialirt_download_instrument_to_csv_mag_uses_ialirt_path_handler(
+    mock_ialirt_data_access: mock.Mock,
+    temp_datastore,  # noqa: F811
+) -> None:
+    fetch = FetchIALiRT(
+        mock_ialirt_data_access,
+        Path(tempfile.mkdtemp()),
+        FileFinder(temp_datastore),
+        IALIRT_PACKET_DEFINITION,
+    )
+
+    mock_ialirt_data_access.get_all_by_dates.side_effect = lambda **_: [
+        {
+            "time_utc": "2026-05-01T00:00:00",
+            "mag_B_GSE": [1, 2, 3],
+            "mag_B_RTN": [4, 5, 6],
+        },
+    ]
+
+    result = fetch.download_instrument_to_csv(
+        instrument="mag",
+        start_date=datetime(2026, 5, 1),
+        end_date=datetime(2026, 5, 2),
+    )
+
+    assert len(result) == 1
+    file_path = next(iter(result.keys()))
+    # MAG keeps original naming (no instrument in filename)
+    assert file_path.name.startswith("imap_ialirt_202605")
+    assert "mag" not in file_path.name

--- a/tests/test_ialirtInstrumentPathHandler.py
+++ b/tests/test_ialirtInstrumentPathHandler.py
@@ -1,0 +1,73 @@
+"""Tests for IALiRTInstrumentPathHandler."""
+
+from datetime import datetime
+
+import pytest
+
+from imap_mag.io.file.IALiRTInstrumentPathHandler import IALiRTInstrumentPathHandler
+
+
+@pytest.mark.parametrize(
+    "instrument",
+    ["hit", "swe", "swapi", "codice_lo", "codice_hi"],
+)
+def test_get_filename(instrument: str) -> None:
+    handler = IALiRTInstrumentPathHandler(
+        instrument=instrument,
+        content_date=datetime(2026, 2, 1),
+    )
+
+    assert handler.get_filename() == f"imap_ialirt_{instrument}_20260201.csv"
+
+
+@pytest.mark.parametrize(
+    "instrument",
+    ["hit", "swe", "swapi", "codice_lo", "codice_hi"],
+)
+def test_get_folder_structure(instrument: str) -> None:
+    handler = IALiRTInstrumentPathHandler(
+        instrument=instrument,
+        content_date=datetime(2026, 2, 1),
+    )
+
+    assert handler.get_folder_structure() == "ialirt/2026/02"
+
+
+@pytest.mark.parametrize(
+    "instrument",
+    ["hit", "swe", "swapi", "codice_lo", "codice_hi"],
+)
+def test_from_filename_roundtrip(instrument: str) -> None:
+    content_date = datetime(2026, 2, 1)
+    original = IALiRTInstrumentPathHandler(
+        instrument=instrument, content_date=content_date
+    )
+
+    parsed = IALiRTInstrumentPathHandler.from_filename(original.get_filename())
+
+    assert parsed is not None
+    assert parsed.instrument == instrument
+    assert parsed.content_date == content_date
+
+
+def test_from_filename_returns_none_for_mag_file() -> None:
+    # The plain MAG file (imap_ialirt_20260201.csv) should NOT match this handler
+    result = IALiRTInstrumentPathHandler.from_filename("imap_ialirt_20260201.csv")
+    assert result is None
+
+
+def test_from_filename_does_not_shadow_hk_handler() -> None:
+    # imap_ialirt_hk_20260201.csv would match with instrument="hk" via IALiRTInstrumentPathHandler.
+    # This is acceptable IF IALiRTHKPathHandler is tried first in FilePathHandlerSelector.
+    # Here we just verify the parse result is internally consistent.
+    result = IALiRTInstrumentPathHandler.from_filename("imap_ialirt_hk_20260201.csv")
+    assert result is not None
+    assert result.instrument == "hk"
+    assert result.content_date == datetime(2026, 2, 1)
+
+
+def test_get_content_date_for_indexing() -> None:
+    content_date = datetime(2026, 5, 3)
+    handler = IALiRTInstrumentPathHandler(instrument="swe", content_date=content_date)
+
+    assert handler.get_content_date_for_indexing() == content_date

--- a/tests/test_pollIALiRT.py
+++ b/tests/test_pollIALiRT.py
@@ -9,7 +9,7 @@ import pytz
 
 from imap_mag.config.AppSettings import AppSettings
 from imap_mag.util import DatetimeProvider, Environment
-from prefect_server.pollIALiRT import poll_ialirt_flow, poll_ialirt_hk_flow
+from prefect_server.pollIALiRT import poll_ialirt_flow
 from tests.util.database import test_database  # noqa: F401
 from tests.util.miscellaneous import (
     END_OF_HOUR,
@@ -22,6 +22,18 @@ from tests.util.prefect_test_utils import (  # noqa: F401
     mock_teams_webhook_block,
     prefect_test_fixture,
 )
+
+
+def define_empty_mappings_for_all_instruments(wiremock_manager):
+    """Add low-priority WireMock stubs that return empty data for any instrument not otherwise stubbed."""
+
+    empty_response = json.dumps({"meta": {"count": 0}, "data": []})
+    wiremock_manager.add_string_mapping(
+        r"/space-weather\?.*",
+        empty_response,
+        is_pattern=True,
+        priority=10,  # lower priority than specific stubs (priority=1)
+    )
 
 
 def define_available_ialirt_mappings(
@@ -159,6 +171,7 @@ async def test_poll_ialirt_autoflow_first_ever_run(
     # Set up.
     wiremock_manager.reset()
 
+    define_empty_mappings_for_all_instruments(wiremock_manager)
     define_available_ialirt_mappings(wiremock_manager, YESTERDAY, END_OF_HOUR)
 
     # Exercise.
@@ -199,6 +212,7 @@ async def test_poll_ialirt_autoflow_continue_from_previous_download(
     test_database.save(workflow_progress)
     wiremock_manager.reset()
 
+    define_empty_mappings_for_all_instruments(wiremock_manager)
     define_available_ialirt_mappings(
         wiremock_manager, progress_timestamp + timedelta(seconds=1), END_OF_HOUR
     )
@@ -238,6 +252,7 @@ async def test_poll_ialirt_autoflow_specify_start_end_dates(
 
     wiremock_manager.reset()
 
+    define_empty_mappings_for_all_instruments(wiremock_manager)
     define_available_ialirt_mappings(wiremock_manager, start_date, end_date)
 
     # Exercise.
@@ -334,6 +349,7 @@ async def test_poll_ialirt_send_quicklook_at_6am_uk_time(
     wiremock_manager.reset()
 
     yesterday, end_of_hour = mock_datetime_provider_for_6am_uk_time
+    define_empty_mappings_for_all_instruments(wiremock_manager)
     define_available_ialirt_mappings(wiremock_manager, yesterday, end_of_hour)
 
     # Exercise.
@@ -366,6 +382,7 @@ async def test_poll_ialirt_hk_autoflow_first_ever_run(
     # Set up.
     wiremock_manager.reset()
 
+    define_empty_mappings_for_all_instruments(wiremock_manager)
     define_available_ialirt_hk_mappings(wiremock_manager, YESTERDAY, END_OF_HOUR)
 
     # Exercise.
@@ -373,8 +390,8 @@ async def test_poll_ialirt_hk_autoflow_first_ever_run(
         IALIRT_DATA_ACCESS_URL=wiremock_manager.get_url().rstrip("/"),
         IALIRT_API_KEY="12345",
     ):
-        await poll_ialirt_hk_flow(
-            wait_for_new_data_to_arrive=False,
+        await poll_ialirt_flow(
+            wait_for_new_data_to_arrive=False, plot_last_3_days=False
         )
 
     # Verify.
@@ -403,6 +420,7 @@ async def test_poll_ialirt_hk_autoflow_specify_start_end_dates(
 
     wiremock_manager.reset()
 
+    define_empty_mappings_for_all_instruments(wiremock_manager)
     define_available_ialirt_hk_mappings(wiremock_manager, start_date, end_date)
 
     # Exercise.
@@ -410,10 +428,11 @@ async def test_poll_ialirt_hk_autoflow_specify_start_end_dates(
         IALIRT_DATA_ACCESS_URL=wiremock_manager.get_url().rstrip("/"),
         IALIRT_API_KEY="12345",
     ):
-        await poll_ialirt_hk_flow(
+        await poll_ialirt_flow(
             wait_for_new_data_to_arrive=False,
             start_date=start_date,
             end_date=end_date,
+            plot_last_3_days=False,
         )
 
     # Verify.


### PR DESCRIPTION
…d CODICE data

- Add 5 new instruments (hit, swe, swapi, codice_lo, codice_hi) to I-ALiRT downloads
- Generalise FetchIALiRT with public download_to_csv and process_ialirt_default for arbitrary instruments
- Add IALiRTInstrumentPathHandler producing ialirt/YYYY/MM/imap_ialirt_<instrument>_YYYYMMDD.csv
- Add IALiRTInstrumentPipeline and DownloadIALiRTStage using the pipeline/stages framework
- Add per-instrument workflow progress IDs in CONSTANTS.DATABASE.IALIRT_INSTRUMENT_PROGRESS_IDS
- Replace two separate Prefect flows (MAG + HK) with one unified poll_ialirt_flow that fans
  out 7 parallel tasks per tick using asyncio.gather
- Add --instrument option to `imap-mag fetch ialirt` CLI command
- Tighten imap_ialirt filename match to imap_ialirt_2*.csv to prevent shadowing new files
- Crump DB ingestion mappings deferred until real CSV data is available

Implements #271 