### PR TITLE
fix: pool SQLAlchemy connections to prevent exhausting postgres

### DIFF
--- a/src/imap_mag/db/Database.py
+++ b/src/imap_mag/db/Database.py
@@ -1,9 +1,12 @@
 import functools
 import logging
 import os
+import threading
 from datetime import datetime
+from typing import ClassVar
 
 from sqlalchemy import create_engine, or_, select
+from sqlalchemy.engine import Engine, make_url
 from sqlalchemy.orm import Session, sessionmaker
 
 from imap_db.model import Base, File, WorkflowProgress
@@ -14,6 +17,8 @@ logger = logging.getLogger(__name__)
 class Database:
     """Database manager."""
 
+    _engine_cache: ClassVar[dict[str, Engine]] = {}
+    _engine_lock: ClassVar[threading.Lock] = threading.Lock()
     __active_session: Session | None
 
     def __init__(self, db_url=None):
@@ -26,7 +31,14 @@ class Database:
                 "No database URL provided. Consider setting SQLALCHEMY_URL environment variable."
             )
 
-        self.engine = create_engine(db_url, pool_pre_ping=True)
+        url = make_url(db_url)
+        url_key = url.render_as_string(hide_password=False)
+
+        with Database._engine_lock:
+            if url_key not in Database._engine_cache:
+                Database._engine_cache[url_key] = create_engine(url, pool_pre_ping=True)
+
+        self.engine = Database._engine_cache[url_key]
         self.session = sessionmaker(bind=self.engine)
 
     @classmethod
@@ -131,7 +143,8 @@ class Database:
 
         logger.debug(f"Executing SQL statement: {statement}")
 
-        return list(self.session().execute(statement).scalars().all())
+        with self.session() as session:
+            return list(session.execute(statement).scalars().all())
 
     def get_files_deleted_since(
         self, last_modified_date: datetime, how_many: int | None = None
@@ -150,7 +163,8 @@ class Database:
 
         logger.debug(f"Executing SQL statement: {statement}")
 
-        return list(self.session().execute(statement).scalars().all())
+        with self.session() as session:
+            return list(session.execute(statement).scalars().all())
 
     @__session_manager(expire_on_commit=False)
     def get_workflow_progress(self, item_name: str) -> WorkflowProgress:
@@ -169,7 +183,8 @@ class Database:
             WorkflowProgress.progress_timestamp.desc()
         )
 
-        return list(self.session().execute(statement).scalars().all())
+        with self.session() as session:
+            return list(session.execute(statement).scalars().all())
 
     @__session_manager()
     def save(self, model: Base) -> None:
@@ -179,7 +194,8 @@ class Database:
     def get_all_active_files(self) -> list[File]:
         """Get all files that have not been deleted."""
         statement = select(File).where(File.deletion_date.is_(None))
-        return list(self.session().execute(statement).scalars().all())
+        with self.session() as session:
+            return list(session.execute(statement).scalars().all())
 
     def get_files_by_path_pattern(self, pattern: str) -> list[File]:
         """Get all active files matching a path pattern (SQL LIKE pattern)."""
@@ -187,7 +203,8 @@ class Database:
             File.deletion_date.is_(None),
             File.path.like(pattern),
         )
-        return list(self.session().execute(statement).scalars().all())
+        with self.session() as session:
+            return list(session.execute(statement).scalars().all())
 
     def get_active_files_matching_patterns(self, patterns: list[str]) -> list[File]:
         """Get all active files matching any of the given fnmatch patterns.
@@ -215,7 +232,8 @@ class Database:
             or_(*pattern_conditions),
         )
 
-        return list(self.session().execute(statement).scalars().all())
+        with self.session() as session:
+            return list(session.execute(statement).scalars().all())
 
     @staticmethod
     def _fnmatch_to_like(pattern: str) -> str:

--- a/tests/imap_mag/db/test_database.py
+++ b/tests/imap_mag/db/test_database.py
@@ -8,14 +8,20 @@ from pathlib import Path
 from unittest import mock
 
 import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
 
-from imap_db.model import File, WorkflowProgress
+from imap_db.model import Base, File, WorkflowProgress
 from imap_mag import __version__
 from imap_mag.db import Database, update_database_with_progress
 from imap_mag.io import (
     IDatastoreFileManager,
 )
-from tests.util.database import test_database  # noqa: F401
+from tests.util.database import (  # noqa: F401
+    test_database,
+    test_database_container,
+    test_database_server_engine,
+)
 from tests.util.miscellaneous import (
     NOW,
     TODAY,
@@ -202,3 +208,71 @@ def test_database_insert_file_same_name_different_hash(
         f"File {test_file2!s} already exists in database with different hash. Replacing."
         in capture_cli_logs.text
     )
+
+
+@pytest.mark.skipif(
+    os.getenv("GITHUB_ACTIONS") and os.getenv("RUNNER_OS") == "Windows",
+    reason="Test containers (used by test database) does not work on Windows",
+)
+def test_multiple_database_instances_share_engine(
+    test_database_server_engine,  # noqa: F811
+) -> None:
+    """Multiple Database instances with the same URL must share one SQLAlchemy engine.
+
+    Before the fix each Database() call created a fresh engine with its own
+    connection pool, so N instances consumed N*pool_size connections and could
+    exhaust the server's max_connections limit.
+    """
+    db1 = Database(db_url=test_database_server_engine.url)
+    db2 = Database(db_url=test_database_server_engine.url)
+    db3 = Database(db_url=test_database_server_engine.url)
+
+    assert db1.engine is db2.engine, (
+        "Database instances with the same URL should reuse one cached engine"
+    )
+    assert db2.engine is db3.engine, (
+        "Database instances with the same URL should reuse one cached engine"
+    )
+
+
+@pytest.mark.skipif(
+    os.getenv("GITHUB_ACTIONS") and os.getenv("RUNNER_OS") == "Windows",
+    reason="Test containers (used by test database) does not work on Windows",
+)
+def test_database_read_methods_return_connections_to_pool(
+    test_database_server_engine,  # noqa: F811
+) -> None:
+    """Read methods must close their sessions so connections return to the pool.
+
+    Before the fix the bare self.session().execute(...) pattern did not
+    guarantee session closure, so connections could remain checked-out and
+    prevent other callers from obtaining one.
+    """
+    # Use a pool with a single connection and no overflow so any leak is immediately visible.
+    constrained_engine = create_engine(
+        test_database_server_engine.url,
+        pool_size=1,
+        max_overflow=0,
+        pool_timeout=1,
+    )
+    Base.metadata.create_all(constrained_engine)
+
+    db = Database.__new__(Database)
+    db.engine = constrained_engine
+    db.session = sessionmaker(bind=constrained_engine)
+
+    since = datetime(2020, 1, 1)
+
+    # Calling the same read methods repeatedly must not exhaust the single pooled connection.
+    for _ in range(5):
+        db.get_files_since(since)
+        db.get_all_active_files()
+        db.get_all_workflow_progress()
+        db.get_files_by_path_pattern("%")
+        db.get_active_files_matching_patterns(["*"])
+
+    assert constrained_engine.pool.checkedout() == 0, (
+        "All connections should be returned to pool after read methods complete"
+    )
+
+    constrained_engine.dispose()


### PR DESCRIPTION
Each Database() call was creating a fresh engine with its own connection pool, so N concurrent flows/tests consumed N*pool_size connections and hit the postgres 'too many clients' limit.

Two fixes:
1. Cache engines at class level keyed by URL so all Database instances with the same URL share one pool.
2. Wrap the six bare self.session().execute() read methods in explicit 'with self.session() as session:' blocks so connections are returned to pool immediately rather than relying on garbage collection.

Regression tests added: test_multiple_database_instances_share_engine (would fail before fix) and test_database_read_methods_return_connections_to_pool.