### PR TITLE
Allow force latest quicklook update for I-ALiRT

### DIFF
--- a/src/imap_mag/cli/plot/plot_ialirt.py
+++ b/src/imap_mag/cli/plot/plot_ialirt.py
@@ -51,6 +51,13 @@ def plot_ialirt(
         SaveMode,
         typer.Option(help="Whether to save locally only or to also save to database"),
     ] = SaveMode.LocalOnly,
+    force_latest_update: Annotated[
+        bool,
+        typer.Option(
+            "--force-latest-update",
+            help="Whether to force the update of the latest image in the database, even if it already exists. This can be useful if you want to ensure that the latest data is always up to date.",
+        ),
+    ] = False,
 ) -> dict[Path, IALiRTQuicklookPathHandler]:
     """Plot I-ALiRT data."""
 
@@ -110,6 +117,7 @@ def plot_ialirt(
                     hour=0, minute=0, second=0, microsecond=0
                 )
                 == DatetimeProvider.today()
+                or force_latest_update
             ):
                 latest_handler = LatestFilePathHandler(
                     root=(

--- a/src/prefect_server/pollIALiRT.py
+++ b/src/prefect_server/pollIALiRT.py
@@ -91,6 +91,15 @@ async def poll_ialirt_flow(
             }
         ),
     ] = False,
+    force_notification: Annotated[
+        bool,
+        Field(
+            json_schema_extra={
+                "title": "Force notification",
+                "description": "If true, the flow will send a notification even if no new data was downloaded.",
+            }
+        ),
+    ] = False,
     wait_for_new_data_to_arrive: Annotated[
         bool,
         Field(
@@ -169,6 +178,7 @@ async def poll_ialirt_flow(
             start_date=DatetimeProvider.today() - timedelta(days=2),
             end_date=DatetimeProvider.now(),
             combined_plot=True,
+            force_latest_update=True,
         )
 
         # If this is the 6 AM (UK time) polling job, send the latest figure to Teams
@@ -176,7 +186,9 @@ async def poll_ialirt_flow(
             pytz.timezone("Europe/London")
         )
 
-        if wait_for_new_data_to_arrive and (uk_end_time.hour == 6):
+        if wait_for_new_data_to_arrive and (
+            uk_end_time.hour == 6 or force_notification
+        ):
             imap_webhook_block = await MicrosoftTeamsWebhook.aload(
                 imap_notification_webhook_name
             )

--- a/src/prefect_server/quicklookIALiRT.py
+++ b/src/prefect_server/quicklookIALiRT.py
@@ -53,6 +53,15 @@ async def quicklook_ialirt_flow(
             }
         ),
     ] = False,
+    force_latest_update: Annotated[
+        bool,
+        Field(
+            json_schema_extra={
+                "title": "Force update of latest image",
+                "description": "Whether to force the update of the latest quicklook I-ALiRT image",
+            }
+        ),
+    ] = False,
 ) -> None:
     """
     Plot I-ALiRT data from data store.
@@ -63,4 +72,5 @@ async def quicklook_ialirt_flow(
         end_date=end_date,
         combined_plot=combined_plot,
         save_mode=SaveMode.LocalAndDatabase,
+        force_latest_update=force_latest_update,
     )

--- a/tests/test_plotIALiRT.py
+++ b/tests/test_plotIALiRT.py
@@ -157,3 +157,36 @@ def test_plot_ialirt_todays_data_added_to_database(
         for file in files_in_db
     )
     assert any(file.path == "quicklook/ialirt/latest.png" for file in files_in_db)
+
+
+def test_force_latest_update_ialirt_plot(
+    temp_datastore: Path,  # noqa: F811
+    test_database,  # noqa: F811
+    mock_datetime_provider_today_20251025,
+    dynamic_work_folder,
+) -> None:
+    # Set up.
+    _setup_ialirt_datastore(temp_datastore, "20251021", "2025/10")
+
+    assert len(test_database.get_files()) == 0
+
+    # Execute.
+    generated_plots = plot_ialirt(
+        start_date=datetime(2025, 10, 21, 0, 0, 0),
+        end_date=datetime(2025, 10, 21, 23, 59, 59),
+        save_mode=SaveMode.LocalAndDatabase,
+        force_latest_update=True,
+    )
+
+    # Verify.
+    assert len(generated_plots) == 1
+    assert (temp_datastore / "quicklook" / "ialirt" / "latest.png").exists()
+
+    files_in_db = test_database.get_files()
+    assert len(files_in_db) == 2
+
+    assert any(
+        file.path == "quicklook/ialirt/2025/10/imap_quicklook_ialirt_20251021.png"
+        for file in files_in_db
+    )
+    assert any(file.path == "quicklook/ialirt/latest.png" for file in files_in_db)

--- a/tests/test_plotIALiRT.py
+++ b/tests/test_plotIALiRT.py
@@ -32,6 +32,11 @@ def mock_datetime_provider_today_20251021(monkeypatch):
     monkeypatch.setattr(DatetimeProvider, "today", lambda: datetime(2025, 10, 21))
 
 
+@pytest.fixture(scope="function", autouse=False)
+def mock_datetime_provider_today_20251025(monkeypatch):
+    monkeypatch.setattr(DatetimeProvider, "today", lambda: datetime(2025, 10, 25))
+
+
 def _setup_ialirt_datastore(
     temp_datastore: Path,  # noqa: F811
     date_str: str,


### PR DESCRIPTION
Adds two I-ALiRT related flags - to be able to force the notification outside of the 6am window, and force an update of the latest file even if it is not the same day as the data within the file. That flag is then raised for runs of `poll_ialirt` that plot the last three days of data, so it now always updates latest. This prevents latest from not being updated if the data was polled and plotted on a different day then the content