### PR TITLE
feature: add split_by_day option to calibration flows

### DIFF
--- a/src/prefect_server/constants.py
+++ b/src/prefect_server/constants.py
@@ -96,6 +96,9 @@ class PREFECT_CONSTANTS:
         DATASTORE_INDEXER = "datastore-indexer"
 
     class DEPLOYMENT_NAMES:
+        CALIBRATE = "calibrate"
+        APPLY_CALIBRATION = "apply"
+        CALIBRATE_AND_APPLY = "calibrate_and_apply"
         POLL_IALIRT = "poll_ialirt"
         POLL_IALIRT_HK = "poll_ialirt_hk"
         POLL_HK = "poll_hk"

--- a/src/prefect_server/performCalibration.py
+++ b/src/prefect_server/performCalibration.py
@@ -1,13 +1,17 @@
 import logging
 import re
 import shutil
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
+from typing import Annotated
 
 from prefect import flow
+from prefect.client.schemas.objects import FlowRun
+from prefect.deployments import run_deployment
 from prefect.filesystems import LocalFileSystem
 from prefect.runtime import flow_run
 from prefect_github import GitHubRepository
+from pydantic import Field
 
 from imap_mag.cli.apply import FileType, apply
 from imap_mag.cli.calibrate import Sensor, calibrate
@@ -29,8 +33,87 @@ from prefect_server.constants import PREFECT_CONSTANTS
 logger = logging.getLogger(__name__)
 
 
+# Shared, self-documenting definition of the split_by_day flow parameter so the
+# title/description show up consistently in the Prefect UI for every flow that
+# supports it (calibrate, apply, calibrate-and-apply).
+SplitByDay = Annotated[
+    bool,
+    Field(
+        json_schema_extra={
+            "title": "Split by day",
+            "description": (
+                "If true and a date range spanning more than one day is given, each "
+                "day is resubmitted as its own deployment flow run so the range is "
+                "processed in daily chunks that can run in parallel across multiple "
+                "servers. If false (the default), the whole range runs sequentially "
+                "within this single flow run."
+            ),
+        },
+    ),
+]
+
+
 class PrefectScriptedL2CalibrationConfig(ScriptedL2CalibrationConfig):
     matlab_repo: LocalFileSystem | GitHubRepository | str | None = None
+
+
+def _days_in_range(start_date: datetime, end_date: datetime | None) -> list[datetime]:
+    """Return each day (inclusive) in the ``[start_date, end_date]`` range.
+
+    A single day is returned when ``end_date`` is ``None`` or equal to ``start_date``.
+
+    Args:
+        start_date: First day of the range.
+        end_date: Last day of the range (inclusive), or ``None`` for a single day.
+
+    Returns:
+        One ``datetime`` per day, preserving the time-of-day of ``start_date``.
+    """
+    effective_end = end_date or start_date
+    num_days = (effective_end.date() - start_date.date()).days + 1
+    return [start_date + timedelta(days=i) for i in range(num_days)]
+
+
+def _submit_days_as_deployment_runs(
+    deployment_name: str,
+    days: list[datetime],
+    base_parameters: dict,
+) -> list[FlowRun]:
+    """Resubmit one deployment flow run per day so a date range fans out across workers.
+
+    Each per-day run is created with ``start_date == end_date`` for that day and
+    ``split_by_day`` disabled, so a worker (potentially on a different server) processes
+    exactly one day. Runs are submitted without waiting for completion (``timeout=0``)
+    so all days are enqueued and picked up in parallel by the worker pool.
+
+    Args:
+        deployment_name: The ``"<flow-name>/<deployment-name>"`` to run for each day.
+        days: The days to submit, one deployment run each.
+        base_parameters: Parameters shared by every day. ``start_date``, ``end_date``
+            and ``split_by_day`` are set per run and must not be included here.
+
+    Returns:
+        The created flow runs, one per day, in the same order as ``days``.
+    """
+    flow_runs: list[FlowRun] = []
+    for day in days:
+        flow_run_result: FlowRun = run_deployment(
+            name=deployment_name,
+            parameters={
+                **base_parameters,
+                "start_date": day,
+                "end_date": day,
+                "split_by_day": False,
+            },
+            as_subflow=True,
+            timeout=0,  # submit and return immediately; do not wait for the day to finish
+        )
+        logger.info(
+            f"Submitted {deployment_name} run for {day.date()} as flow run "
+            f"'{flow_run_result.name}' ({flow_run_result.id})"
+        )
+        flow_runs.append(flow_run_result)
+    return flow_runs
 
 
 def _github_repo_name(repository_url: str) -> str:
@@ -187,7 +270,22 @@ def calibrate_flow(
     sensor: Sensor = Sensor.MAGO,
     save_mode: SaveMode = SaveMode.LocalAndDatabase,
     metakernel: Path | None = None,
-) -> list[Path]:
+    split_by_day: SplitByDay = False,
+) -> list[Path] | list[FlowRun]:
+
+    days = _days_in_range(start_date, end_date)
+    if split_by_day and len(days) > 1:
+        return _submit_days_as_deployment_runs(
+            deployment_name=f"{PREFECT_CONSTANTS.FLOW_NAMES.CALIBRATE}/{PREFECT_CONSTANTS.DEPLOYMENT_NAMES.CALIBRATE}",
+            days=days,
+            base_parameters={
+                "configuration": configuration,
+                "mode": mode,
+                "sensor": sensor,
+                "save_mode": save_mode,
+                "metakernel": metakernel,
+            },
+        )
 
     paths = _run_calibration(
         configuration, start_date, end_date, mode, sensor, save_mode, metakernel
@@ -213,7 +311,24 @@ def calibrate_and_apply_flow(
     L2_output_type: FileType = FileType.CDF,
     save_mode: SaveMode = SaveMode.LocalAndDatabase,
     metakernel: Path | None = None,
-):
+    split_by_day: SplitByDay = False,
+) -> None | list[FlowRun]:
+    days = _days_in_range(start_date, end_date)
+    if split_by_day and len(days) > 1:
+        return _submit_days_as_deployment_runs(
+            deployment_name=f"{PREFECT_CONSTANTS.FLOW_NAMES.CALIBRATE_AND_APPLY}/{PREFECT_CONSTANTS.DEPLOYMENT_NAMES.CALIBRATE_AND_APPLY}",
+            days=days,
+            base_parameters={
+                "configuration": configuration,
+                "mode": mode,
+                "sensor": sensor,
+                "offset_file_output_type": offset_file_output_type,
+                "L2_output_type": L2_output_type,
+                "save_mode": save_mode,
+                "metakernel": metakernel,
+            },
+        )
+
     cal_layer_paths = _run_calibration(
         configuration, start_date, end_date, mode, sensor, save_mode, metakernel
     )
@@ -288,7 +403,26 @@ def apply_flow(
         ReferenceFrame.GSE,
         ReferenceFrame.SRF,
     ],
-):
+    split_by_day: SplitByDay = False,
+) -> None | list[FlowRun]:
+    days = _days_in_range(start_date, end_date)
+    if split_by_day and len(days) > 1:
+        return _submit_days_as_deployment_runs(
+            deployment_name=f"{PREFECT_CONSTANTS.FLOW_NAMES.APPLY_CALIBRATION}/{PREFECT_CONSTANTS.DEPLOYMENT_NAMES.APPLY_CALIBRATION}",
+            days=days,
+            base_parameters={
+                "layers": layers,
+                "mode": mode,
+                "science_input_file": science_input_file,
+                "offset_file_output_type": offset_file_output_type,
+                "L2_output_type": L2_output_type,
+                "save_mode": save_mode,
+                "rotation_calibration_file_name": rotation_calibration_file_name,
+                "spice_metakernel": spice_metakernel,
+                "reference_frames": reference_frames,
+            },
+        )
+
     apply(
         layers,
         start_date=start_date.replace(tzinfo=None),

--- a/src/prefect_server/workflow.py
+++ b/src/prefect_server/workflow.py
@@ -412,7 +412,7 @@ async def adeploy_flows(local_debug: bool = False):
     matlab_shared_job_variables["memswap_limit"] = "4g"
 
     calibration_deployable = calibrate_flow.to_deployment(
-        name="calibrate",
+        name=PREFECT_CONSTANTS.DEPLOYMENT_NAMES.CALIBRATE,
         job_variables=matlab_shared_job_variables,
         work_queue_name=PREFECT_CONSTANTS.QUEUES.LOW_BIG,
         tags=[PREFECT_CONSTANTS.PREFECT_TAG],
@@ -423,14 +423,14 @@ async def adeploy_flows(local_debug: bool = False):
     apply_shared_job_variables["memswap_limit"] = "6g"
 
     apply_deployable = apply_flow.to_deployment(
-        name="apply",
+        name=PREFECT_CONSTANTS.DEPLOYMENT_NAMES.APPLY_CALIBRATION,
         job_variables=apply_shared_job_variables,
         work_queue_name=PREFECT_CONSTANTS.QUEUES.LOW_BIG,
         tags=[PREFECT_CONSTANTS.PREFECT_TAG],
     )
 
     calibrate_and_apply_deployable = calibrate_and_apply_flow.to_deployment(
-        name="calibrate_and_apply",
+        name=PREFECT_CONSTANTS.DEPLOYMENT_NAMES.CALIBRATE_AND_APPLY,
         job_variables=apply_shared_job_variables,
         work_queue_name=PREFECT_CONSTANTS.QUEUES.LOW_BIG,
         tags=[PREFECT_CONSTANTS.PREFECT_TAG],

--- a/tests/unit/test_performCalibration.py
+++ b/tests/unit/test_performCalibration.py
@@ -13,8 +13,10 @@ from mag_toolkit.calibration.CalibrationConfig import GradiometryConfig
 from prefect_server.constants import PREFECT_CONSTANTS
 from prefect_server.performCalibration import (
     PrefectScriptedL2CalibrationConfig,
+    _days_in_range,
     _github_repo_name,
     _resolve_matlab_repo_path,
+    apply_flow,
     calibrate_and_apply_flow,
     calibrate_flow,
     generate_apply_calibration_flow_run_name,
@@ -186,8 +188,6 @@ class TestPerformCalibrationFlows:
         mock_calibrate.assert_called_once()
 
     def test_apply_flow_calls_apply(self):
-        from prefect_server.performCalibration import apply_flow
-
         with patch("prefect_server.performCalibration.apply") as mock_apply:
             mock_apply.return_value = []
             apply_flow.fn(
@@ -195,6 +195,183 @@ class TestPerformCalibrationFlows:
                 start_date=datetime(2025, 1, 1),
             )
 
+        mock_apply.assert_called_once()
+
+
+class TestDaysInRange:
+    def test_single_day_when_end_date_none(self):
+        assert _days_in_range(datetime(2025, 1, 5), None) == [datetime(2025, 1, 5)]
+
+    def test_single_day_when_end_equals_start(self):
+        assert _days_in_range(datetime(2025, 1, 5), datetime(2025, 1, 5)) == [
+            datetime(2025, 1, 5)
+        ]
+
+    def test_inclusive_range(self):
+        days = _days_in_range(datetime(2025, 1, 1), datetime(2025, 1, 3))
+        assert days == [
+            datetime(2025, 1, 1),
+            datetime(2025, 1, 2),
+            datetime(2025, 1, 3),
+        ]
+
+    def test_preserves_time_of_day(self):
+        days = _days_in_range(datetime(2025, 1, 1, 6, 30), datetime(2025, 1, 2, 6, 30))
+        assert days == [
+            datetime(2025, 1, 1, 6, 30),
+            datetime(2025, 1, 2, 6, 30),
+        ]
+
+
+class TestSplitByDay:
+    """split_by_day fans a date range out into one deployment run per day."""
+
+    def _make_flow_run(self, name):
+        fake = MagicMock()
+        fake.name = name
+        return fake
+
+    def test_calibrate_flow_splits_range_into_per_day_deployment_runs(self):
+        with (
+            patch(
+                "prefect_server.performCalibration.run_deployment",
+                side_effect=lambda **kwargs: self._make_flow_run(
+                    str(kwargs["parameters"]["start_date"])
+                ),
+            ) as mock_run_deployment,
+            patch("prefect_server.performCalibration.calibrate") as mock_calibrate,
+        ):
+            result = calibrate_flow.fn(
+                start_date=datetime(2025, 1, 1),
+                end_date=datetime(2025, 1, 3),
+                configuration=GradiometryConfig(),
+                split_by_day=True,
+            )
+
+        # one deployment run per day, and the local calibration never runs
+        assert mock_run_deployment.call_count == 3
+        assert len(result) == 3
+        mock_calibrate.assert_not_called()
+
+        # each child run targets a single day with split_by_day disabled
+        for call, day in zip(
+            mock_run_deployment.call_args_list,
+            [datetime(2025, 1, 1), datetime(2025, 1, 2), datetime(2025, 1, 3)],
+        ):
+            params = call.kwargs["parameters"]
+            assert params["start_date"] == day
+            assert params["end_date"] == day
+            assert params["split_by_day"] is False
+            assert call.kwargs["timeout"] == 0
+            assert (
+                call.kwargs["name"]
+                == f"{PREFECT_CONSTANTS.FLOW_NAMES.CALIBRATE}/{PREFECT_CONSTANTS.DEPLOYMENT_NAMES.CALIBRATE}"
+            )
+
+    def test_calibrate_flow_single_day_runs_inline_even_when_split_requested(self):
+        with (
+            patch(
+                "prefect_server.performCalibration.run_deployment"
+            ) as mock_run_deployment,
+            patch(
+                "prefect_server.performCalibration.calibrate",
+                return_value=[Path("layer.json")],
+            ) as mock_calibrate,
+        ):
+            calibrate_flow.fn(
+                start_date=datetime(2025, 1, 1),
+                configuration=GradiometryConfig(),
+                split_by_day=True,
+            )
+
+        mock_run_deployment.assert_not_called()
+        mock_calibrate.assert_called_once()
+
+    def test_calibrate_flow_range_without_split_runs_inline(self):
+        with (
+            patch(
+                "prefect_server.performCalibration.run_deployment"
+            ) as mock_run_deployment,
+            patch(
+                "prefect_server.performCalibration.calibrate",
+                return_value=[Path("layer.json")],
+            ) as mock_calibrate,
+        ):
+            calibrate_flow.fn(
+                start_date=datetime(2025, 1, 1),
+                end_date=datetime(2025, 1, 3),
+                configuration=GradiometryConfig(),
+                split_by_day=False,
+            )
+
+        mock_run_deployment.assert_not_called()
+        mock_calibrate.assert_called_once()
+
+    def test_calibrate_and_apply_flow_splits_range(self):
+        with (
+            patch(
+                "prefect_server.performCalibration.run_deployment",
+                return_value=self._make_flow_run("child"),
+            ) as mock_run_deployment,
+            patch("prefect_server.performCalibration.calibrate") as mock_calibrate,
+            patch("prefect_server.performCalibration.apply") as mock_apply,
+        ):
+            result = calibrate_and_apply_flow.fn(
+                configuration=GradiometryConfig(),
+                start_date=datetime(2025, 1, 1),
+                end_date=datetime(2025, 1, 2),
+                split_by_day=True,
+            )
+
+        assert mock_run_deployment.call_count == 2
+        assert len(result) == 2
+        mock_calibrate.assert_not_called()
+        mock_apply.assert_not_called()
+        assert (
+            mock_run_deployment.call_args.kwargs["name"]
+            == f"{PREFECT_CONSTANTS.FLOW_NAMES.CALIBRATE_AND_APPLY}/{PREFECT_CONSTANTS.DEPLOYMENT_NAMES.CALIBRATE_AND_APPLY}"
+        )
+
+    def test_apply_flow_splits_range(self):
+        with (
+            patch(
+                "prefect_server.performCalibration.run_deployment",
+                return_value=self._make_flow_run("child"),
+            ) as mock_run_deployment,
+            patch("prefect_server.performCalibration.apply") as mock_apply,
+        ):
+            result = apply_flow.fn(
+                layers=["*noop*"],
+                start_date=datetime(2025, 1, 1),
+                end_date=datetime(2025, 1, 3),
+                split_by_day=True,
+            )
+
+        assert mock_run_deployment.call_count == 3
+        assert len(result) == 3
+        mock_apply.assert_not_called()
+        first_params = mock_run_deployment.call_args_list[0].kwargs["parameters"]
+        assert first_params["layers"] == ["*noop*"]
+        assert first_params["split_by_day"] is False
+        assert (
+            mock_run_deployment.call_args.kwargs["name"]
+            == f"{PREFECT_CONSTANTS.FLOW_NAMES.APPLY_CALIBRATION}/{PREFECT_CONSTANTS.DEPLOYMENT_NAMES.APPLY_CALIBRATION}"
+        )
+
+    def test_apply_flow_default_does_not_split(self):
+        with (
+            patch(
+                "prefect_server.performCalibration.run_deployment"
+            ) as mock_run_deployment,
+            patch("prefect_server.performCalibration.apply") as mock_apply,
+        ):
+            apply_flow.fn(
+                layers=["*noop*"],
+                start_date=datetime(2025, 1, 1),
+                end_date=datetime(2025, 1, 3),
+            )
+
+        mock_run_deployment.assert_not_called()
         mock_apply.assert_called_once()
 
 


### PR DESCRIPTION
## Summary

Adds a non-default `split_by_day` boolean parameter to the **calibrate**, **apply** and **calibrate-and-apply** Prefect flows so a date-range run can be either processed sequentially in a single flow run, or fanned out into daily chunks that run in parallel across the worker pool (in prod, 3 servers).

- `split_by_day` is **`False` by default**, so existing behaviour is unchanged: a date range runs as one sequential process in the flow run.
- When `split_by_day=True` **and** the range spans more than one day, each day is resubmitted as its own deployment flow run (`start_date == end_date`, `split_by_day` disabled) via `run_deployment` with `timeout=0` (submit-and-return, don't wait). The days are enqueued and picked up in parallel by workers on different servers.
- A single day (or `end_date` omitted/equal to `start_date`) always runs inline, even if `split_by_day=True`, so no pointless child deployment is created.

This mirrors the `split_into_days` pattern used in the sibling project's autoflow-by-date flow.

## Changes

- **`performCalibration.py`**
  - Shared `SplitByDay` annotated type providing a consistent title/description for the parameter in the Prefect UI across all three flows.
  - `_days_in_range(...)` helper to enumerate the inclusive day list for a range.
  - `_submit_days_as_deployment_runs(...)` helper that submits one deployment run per day (`as_subflow=True`, `timeout=0`).
  - `split_by_day` parameter and early split branch added to `calibrate_flow`, `apply_flow` and `calibrate_and_apply_flow`.
- **`constants.py`** — promote the `calibrate` / `apply` / `calibrate_and_apply` deployment names into `PREFECT_CONSTANTS.DEPLOYMENT_NAMES` so both the deployment definitions and the `run_deployment` calls reference the same constants.
- **`workflow.py`** — use the new deployment-name constants instead of hardcoded strings.

## Testing

- Added `TestDaysInRange` and `TestSplitByDay` unit tests covering: per-day fan-out for each of the three flows, single-day/range-without-split running inline, correct per-day parameters (`start_date == end_date`, `split_by_day=False`, `timeout=0`, deployment name), and the default (no-split) path.
- Verified each flow's generated Prefect parameter schema exposes `split_by_day` with `default=False`, title and description.
- `poetry run pytest tests/unit/` — **998 passed**.
- `ruff check` / `ruff format` clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_019gSTBJNPYi3tDcQrYPPsoF)_