### PR TITLE
fix: rename legacy layer CSV files missed by prior migration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 requires-python = ">=3.11,<3.13" # blocked by imap_processing https://github.com/IMAP-Science-Operations-Center/imap_processing/blob/dev/pyproject.toml#L17
 name = "imap-mag"
-version = "6.0.0"
+version = "6.0.1"
 description = "Process IMAP data"
 authors = [
   {name = "alastairtree"},

--- a/src/imap_db/migrations/versions/2026_07_17-e5f6a7b8c9d0_rename_legacy_layer_csv_files.py
+++ b/src/imap_db/migrations/versions/2026_07_17-e5f6a7b8c9d0_rename_legacy_layer_csv_files.py
@@ -1,0 +1,218 @@
+"""Rename layer CSV files still using the legacy _vNNN naming scheme.
+
+Migration ``d4e5f6a7b8c9`` (rename_layer_files_to_major_version) renamed layer
+JSON files from the legacy ``_vNNN.json`` naming to the new
+``_v001.NNNN.json`` major-version scheme, and was supposed to rename each
+JSON's companion CSV file at the same time. It had a bug: it derived the old
+CSV filename via ``old_json_name.replace(".json", ".csv")``, but the CSV
+files are not named the same as their JSON siblings -- they use a
+``-layer-data`` descriptor rather than ``-layer`` (e.g.
+``imap_mag_manual-norm-layer-data_20260428_v041.csv``). Because that
+computed name never matched a real file, the CSV rename/DB-update was
+silently skipped for every layer pair, even though it ran in production.
+
+This migration completes the original intent. For each active layer JSON
+file (already renamed to the new ``_v001.NNNN.json`` scheme) it:
+  1. Reads ``metadata.data_filename`` from the JSON -- already rewritten to
+     the new-style CSV name by the previous migration.
+  2. Derives the legacy CSV name by converting the new-style version suffix
+     (``_v001.NNNN``) back to the legacy suffix (``_vNNN``).
+  3. Looks up the CSV's database record under its legacy name.
+  4. Renames the CSV file on disk to the new-style name.
+  5. Updates the CSV's ``files`` row (name, path, version_major) to match.
+
+The JSON file and its metadata are not modified -- they were already
+corrected by the previous migration.
+
+The downgrade is intentionally a no-op: reverting filename changes on disk
+is error-prone and the old naming scheme is considered superseded.
+
+Revision ID: e5f6a7b8c9d0
+Revises: d4e5f6a7b8c9
+Create Date: 2026-07-17 00:00:00.000000
+
+"""
+
+import json
+import logging
+import os
+import re
+from pathlib import Path
+
+import sqlalchemy as sa
+from alembic import op
+
+from imap_mag import __version__
+
+# revision identifiers, used by Alembic.
+revision = "e5f6a7b8c9d0"
+down_revision = "d4e5f6a7b8c9"
+branch_labels = None
+depends_on = None
+
+logger = logging.getLogger(__name__)
+
+_LAYER_JSON_LIKE = "%-layer%.json"
+_NEW_CSV_VERSION_RE = re.compile(r"_v001\.(\d+)\.csv$")
+
+
+def _legacy_csv_name(new_csv_name: str) -> str | None:
+    """Convert a new-style ``_v001.NNNN.csv`` CSV name to its legacy ``_vNNN.csv`` name.
+
+    Args:
+        new_csv_name: CSV filename using the new major-version naming scheme.
+
+    Returns:
+        The equivalent legacy-format CSV filename, or None if new_csv_name
+        does not match the expected new-style version suffix.
+    """
+    match = _NEW_CSV_VERSION_RE.search(new_csv_name)
+    if not match:
+        return None
+
+    minor = int(match.group(1))
+    return new_csv_name[: match.start()] + f"_v{minor:03d}.csv"
+
+
+def _run_migration(connection: sa.engine.Connection, datastore_path: Path) -> None:
+    """Rename legacy layer CSV files that Migration B failed to rename.
+
+    Separated from upgrade() so it can be called directly in tests with an
+    arbitrary datastore path and connection.
+
+    Args:
+        connection: Active SQLAlchemy connection used for DB updates.
+        datastore_path: Root path of the datastore on disk.
+    """
+    rows = connection.execute(
+        sa.text(
+            "SELECT id, name, path FROM files "
+            "WHERE name LIKE :pattern AND deletion_date IS NULL"
+        ),
+        {"pattern": _LAYER_JSON_LIKE},
+    ).fetchall()
+
+    logger.info(
+        f"Found {len(rows)} active layer JSON files to inspect in {datastore_path}."
+    )
+
+    for _file_id, json_name, json_path in rows:
+        json_disk_path = datastore_path / json_path
+        if not json_disk_path.exists():
+            logger.warning(f"JSON file {json_disk_path} not found on disk. Skipping.")
+            continue
+
+        try:
+            with open(json_disk_path) as f:
+                data = json.load(f)
+        except Exception as e:
+            logger.warning(f"Could not read JSON {json_name}: {e}. Skipping.")
+            continue
+
+        new_csv_name = (
+            data.get("metadata", {}).get("data_filename")
+            if isinstance(data, dict)
+            else None
+        )
+        if not new_csv_name:
+            logger.debug(f"No metadata.data_filename found in {json_name}; skipping.")
+            continue
+
+        # --- already renamed? ---
+        already_done = connection.execute(
+            sa.text(
+                "SELECT id FROM files WHERE name = :name AND deletion_date IS NULL"
+            ),
+            {"name": new_csv_name},
+        ).fetchone()
+        if already_done is not None:
+            logger.debug(f"CSV {new_csv_name} already renamed. Skipping.")
+            continue
+
+        old_csv_name = _legacy_csv_name(new_csv_name)
+        if old_csv_name is None:
+            logger.warning(
+                f"Could not derive legacy CSV name from {new_csv_name!r} "
+                f"(referenced by {json_name}). Skipping."
+            )
+            continue
+
+        # --- look up legacy CSV row in DB ---
+        csv_row = connection.execute(
+            sa.text(
+                "SELECT id, path FROM files "
+                "WHERE name = :csv_name AND deletion_date IS NULL"
+            ),
+            {"csv_name": old_csv_name},
+        ).fetchone()
+
+        if csv_row is None:
+            logger.warning(
+                f"No DB record found for legacy CSV {old_csv_name!r} "
+                f"(referenced by {json_name}). Skipping."
+            )
+            continue
+
+        new_csv_path = csv_row.path.replace(old_csv_name, new_csv_name)
+
+        # --- rename CSV file on disk ---
+        old_csv_disk_path = datastore_path / csv_row.path
+        new_csv_disk_path = datastore_path / new_csv_path
+
+        if old_csv_disk_path.exists():
+            try:
+                new_csv_disk_path.parent.mkdir(parents=True, exist_ok=True)
+                old_csv_disk_path.rename(new_csv_disk_path)
+                logger.info(f"Renamed CSV: {old_csv_name} -> {new_csv_name}")
+            except OSError as e:
+                logger.error(
+                    f"Failed to rename {old_csv_disk_path}: {e}. Skipping row."
+                )
+                continue
+        else:
+            logger.warning(
+                f"CSV file {old_csv_disk_path} not found on disk; updating DB only."
+            )
+
+        # --- update DB: CSV row ---
+        connection.execute(
+            sa.text(
+                "UPDATE files "
+                "SET name = :name, path = :path, version_major = 1, "
+                "last_modified_date = CURRENT_TIMESTAMP, software_version = :software_version "
+                "WHERE id = :id"
+            ),
+            {
+                "name": new_csv_name,
+                "path": new_csv_path,
+                "id": csv_row.id,
+                "software_version": __version__,
+            },
+        )
+        logger.info(f"Updated DB record for CSV {old_csv_name} -> {new_csv_name}.")
+
+
+def upgrade() -> None:
+    """Run the legacy layer CSV rename migration."""
+    datastore: Path | None = None
+    try:
+        from imap_mag.config.AppSettings import AppSettings
+
+        datastore = AppSettings().data_store  # type: ignore
+    except Exception:
+        env_val = os.environ.get("MAG_DATA_STORE")
+        if env_val:
+            datastore = Path(env_val)
+
+    if datastore is None:
+        logger.warning(
+            "Datastore path not available (set MAG_DATA_STORE or configure AppSettings). "
+            "Skipping legacy layer CSV rename migration."
+        )
+        return
+
+    _run_migration(op.get_bind(), datastore)
+
+
+def downgrade() -> None:
+    pass  # Intentional no-op: reverting on-disk renames is not supported.

--- a/tests/integration/test_migrate_legacy_layer_csv_files.py
+++ b/tests/integration/test_migrate_legacy_layer_csv_files.py
@@ -1,0 +1,242 @@
+"""Tests for the 2026_07_17-e5f6a7b8c9d0_rename_legacy_layer_csv_files migration.
+
+Migration B (2026_07_09-d4e5f6a7b8c9_rename_layer_files_to_major_version) renamed
+layer JSON files to the new _v001.NNNN naming scheme, but had a bug that meant the
+companion CSV file (which is not named the same as the JSON, e.g.
+``imap_mag_<descriptor>-layer-data_<date>_v<NNN>.csv`` vs.
+``imap_mag_<descriptor>-layer_<date>_v<NNN>.json``) was never found, so it was
+never renamed on disk or in the database, even though the JSON's
+metadata.data_filename was already rewritten to reference the new-style CSV name.
+
+Migration C (this one) re-derives the legacy CSV name from the new-style name
+referenced in the already-migrated JSON, finds the CSV's DB record under its
+legacy name, renames the file on disk, and updates its DB record.
+"""
+
+import importlib.util
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from imap_db.model import File
+from imap_mag import __version__
+from tests.util.database import test_database, test_database_server_engine  # noqa: F401
+
+# ---------------------------------------------------------------------------
+# Load Migration C via importlib (filename contains dashes)
+# ---------------------------------------------------------------------------
+_MIGRATION_C_PATH = (
+    Path(__file__).parent.parent.parent
+    / "src/imap_db/migrations/versions/2026_07_17-e5f6a7b8c9d0_rename_legacy_layer_csv_files.py"
+)
+_spec_c = importlib.util.spec_from_file_location(
+    "rename_legacy_layer_csv_files", _MIGRATION_C_PATH
+)
+_migration_c = importlib.util.module_from_spec(_spec_c)  # type: ignore[arg-type]
+_spec_c.loader.exec_module(_migration_c)  # type: ignore[union-attr]
+_run_migration_c = _migration_c._run_migration
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_post_migration_b_layer_pair(
+    folder: Path, descriptor: str, date: datetime, minor: int, csv_content: str
+) -> tuple[Path, Path, str]:
+    """Write files reproducing the state left behind by buggy Migration B.
+
+    The JSON is already renamed to the new _v001.NNNN scheme, and its
+    metadata.data_filename already references the new-style CSV name -- but
+    the CSV file itself is still sitting on disk under its legacy name
+    (``-layer-data_..._vNNN.csv``), because Migration B's buggy lookup never
+    found it.
+
+    Args:
+        folder: Directory in which to create the files.
+        descriptor: Layer descriptor, e.g. ``"quality-norm"``.
+        date: Content date of the layer.
+        minor: Minor version number (e.g. 41 -> _v001.0041 / legacy _v041).
+        csv_content: Text content for the companion CSV file.
+
+    Returns:
+        Tuple of (json_path, legacy_csv_path, new_csv_name).
+    """
+    date_str = date.strftime("%Y%m%d")
+    json_name = f"imap_mag_{descriptor}-layer_{date_str}_v001.{minor:04d}.json"
+    new_csv_name = f"imap_mag_{descriptor}-layer-data_{date_str}_v001.{minor:04d}.csv"
+    legacy_csv_name = f"imap_mag_{descriptor}-layer-data_{date_str}_v{minor:03d}.csv"
+
+    legacy_csv_path = folder / legacy_csv_name
+    legacy_csv_path.write_text(csv_content)
+
+    json_data = {
+        "metadata": {
+            "data_filename": new_csv_name,
+            "dependencies": [],
+            "science": [],
+            "creation_timestamp": str(date),
+            "content_date": str(date),
+        }
+    }
+    json_path = folder / json_name
+    json_path.write_text(json.dumps(json_data, indent=2))
+
+    assert json_path.exists(), f"Helper failed to create JSON file: {json_path}"
+    assert legacy_csv_path.exists(), (
+        f"Helper failed to create legacy CSV file: {legacy_csv_path}"
+    )
+    return json_path, legacy_csv_path, new_csv_name
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    os.getenv("GITHUB_ACTIONS") and os.getenv("RUNNER_OS") == "Windows",
+    reason="Test containers do not work on Windows GitHub Actions",
+)
+def test_migrate_legacy_layer_csv_files_renames_csv_and_updates_db(
+    test_database,  # noqa: F811
+    test_database_server_engine,  # noqa: F811
+    tmp_path,
+) -> None:
+    """Migration C renames a legacy layer-data CSV left behind by buggy Migration B.
+
+    Scenario:
+        - The layer JSON has already been renamed to the new _v001.0041 scheme
+          (by Migration B) and its metadata.data_filename already points at the
+          new-style CSV name.
+        - The companion CSV file is still on disk (and in the DB) under its
+          legacy name, since Migration B's buggy lookup never matched it.
+        - Migration C is applied once (functional) and then again (idempotency
+          check).
+
+    Assertions:
+        a) The CSV file is renamed on disk to the new-style name.
+        b) The legacy CSV file no longer exists on disk.
+        c) The JSON file and its metadata are left untouched.
+        d) The CSV DB row is updated to the new name/path with version_major=1.
+        e) A second run of Migration C raises no errors and leaves data unchanged.
+    """
+    date = datetime(2026, 4, 28)
+    initial_last_modified = datetime(2026, 4, 28, 12, 0, 0)
+    csv_content = "time,offset_x,offset_y,offset_z\n2026-04-28T00:00:00,1.0,2.0,3.0\n"
+
+    store_dir = tmp_path / "calibration" / "layers" / "2026" / "04"
+    store_dir.mkdir(parents=True)
+
+    json_path, legacy_csv_path, new_csv_name = _write_post_migration_b_layer_pair(
+        store_dir, "manual-norm", date, 41, csv_content
+    )
+    original_json_text = json_path.read_text()
+
+    new_csv_path = store_dir / new_csv_name
+
+    relative_json = json_path.relative_to(tmp_path).as_posix()
+    relative_legacy_csv = legacy_csv_path.relative_to(tmp_path).as_posix()
+
+    # Insert DB records simulating the state left after buggy Migration B ran:
+    # JSON already has version_major=1 and the new name; CSV is untouched
+    # (still legacy name/path, version_major=0).
+    test_database.upsert_files(
+        [
+            File(
+                name=json_path.name,
+                path=relative_json,
+                descriptor="imap_mag_manual-norm-layer",
+                version=41,
+                version_major=1,
+                hash="placeholder_json_hash",
+                size=json_path.stat().st_size,
+                content_date=date,
+                creation_date=datetime(2026, 4, 28, 12, 0, 0),
+                last_modified_date=initial_last_modified,
+                software_version=__version__,
+            ),
+            File(
+                name=legacy_csv_path.name,
+                path=relative_legacy_csv,
+                descriptor="imap_mag_manual-norm-layer-data",
+                version=41,
+                version_major=0,
+                hash="placeholder_csv_hash",
+                size=legacy_csv_path.stat().st_size,
+                content_date=date,
+                creation_date=datetime(2026, 4, 28, 12, 0, 0),
+                last_modified_date=initial_last_modified,
+                software_version="0.0.0",
+            ),
+        ]
+    )
+
+    # Run Migration C (the legacy CSV rename migration).
+    with test_database_server_engine.begin() as conn:
+        _run_migration_c(conn, tmp_path)
+
+    # --- Assertion (a): renamed CSV exists on disk ---
+    assert new_csv_path.exists(), (
+        f"Expected renamed CSV {new_csv_name!r} to exist after migration."
+    )
+
+    # --- Assertion (b): legacy CSV no longer exists ---
+    assert not legacy_csv_path.exists(), (
+        f"Legacy CSV {legacy_csv_path.name!r} should have been removed by migration."
+    )
+
+    # --- Assertion (c): JSON untouched ---
+    assert json_path.exists(), "JSON file should not have been moved or removed."
+    assert json_path.read_text() == original_json_text, (
+        "JSON file contents should be untouched by Migration C."
+    )
+
+    # --- Assertion (d): DB records updated ---
+    db_files = test_database.get_files()
+    csv_records = [f for f in db_files if f.name == new_csv_name]
+    json_records = [f for f in db_files if f.name == json_path.name]
+
+    assert len(csv_records) == 1, (
+        f"Expected exactly one DB record with name {new_csv_name!r}; got {len(csv_records)}."
+    )
+    assert csv_records[0].version_major == 1, (
+        f"CSV DB record version_major should be 1, got {csv_records[0].version_major}."
+    )
+    assert csv_records[0].path == f"calibration/layers/2026/04/{new_csv_name}", (
+        f"CSV DB record path mismatch: {csv_records[0].path!r}."
+    )
+    assert csv_records[0].software_version == __version__, (
+        "CSV DB record software_version should be set to the current package version."
+    )
+    assert csv_records[0].last_modified_date > initial_last_modified, (
+        "CSV DB record last_modified_date should be updated during migration."
+    )
+
+    assert len(json_records) == 1, "JSON DB record should be unaffected."
+    assert json_records[0].last_modified_date == initial_last_modified, (
+        "JSON DB record should not be touched by Migration C."
+    )
+
+    # --- Assertion (e): idempotency - second run must not raise ---
+    with test_database_server_engine.begin() as conn:
+        _run_migration_c(conn, tmp_path)
+
+    assert new_csv_path.exists(), (
+        "CSV file should still exist after idempotent second migration run."
+    )
+    db_files_after = test_database.get_files()
+    assert len(db_files_after) == 2, (
+        "DB record count should be unchanged after idempotent second migration run."
+    )
+    csv_records_after = [f for f in db_files_after if f.name == new_csv_name]
+    assert len(csv_records_after) == 1, (
+        "Should still be exactly one CSV DB record after second run."
+    )
+    assert csv_records_after[0].version_major == 1, (
+        "CSV DB record version_major should still be 1 after second run."
+    )


### PR DESCRIPTION
## Summary
- The `rename_layer_files_to_major_version` migration renamed layer JSON files to the new `_v001.NNNN` naming scheme, but had a bug: it derived the companion CSV's legacy name via `old_json_name.replace(".json", ".csv")`, whereas layer CSV files use a `-layer-data` descriptor rather than `-layer` (e.g. `imap_mag_manual-norm-layer-data_20260428_v041.csv`). The lookup never matched, so the CSV file/DB record was silently left un-renamed even though it ran in production.
- Adds a new migration that re-derives the legacy CSV name from the `metadata.data_filename` already rewritten in each migrated JSON file, finds the CSV's DB record under its legacy name, renames the file on disk, and updates its DB record — completing the original migration's intent without touching the JSON files (which are already correct).

## Test plan
- [x] New integration test `tests/integration/test_migrate_legacy_layer_csv_files.py` reproduces the post-buggy-migration state and asserts the CSV is renamed on disk/DB, the JSON is untouched, and the migration is idempotent.
- [x] `poetry run pytest tests/integration/test_migrate_legacy_layer_csv_files.py tests/integration/test_migrate_major_version.py tests/integration/test_migrate_layer_files.py` passes.
- [x] `poetry run pre-commit run --files <new files>` passes (ruff check/format).