### PR TITLE
Add NOAA pipeline

### DIFF
--- a/src/imap_mag/data_pipelines/DownloadNOAAStage.py
+++ b/src/imap_mag/data_pipelines/DownloadNOAAStage.py
@@ -1,0 +1,48 @@
+from imap_mag.data_pipelines import PROGRESS_DATE_CONTEXT_KEY, FileRecord, Record, Stage
+from imap_mag.download.FetchNOAA import FetchNOAA
+
+
+class DownloadNOAAStage(Stage):
+    """Download NOAA RTSW data for a spacecraft/instrument and emit one FileRecord per downloaded day."""
+
+    def __init__(
+        self,
+        spacecraft: str,
+        instrument: str,
+        fetcher: FetchNOAA,
+    ):
+        """Initialise the stage.
+
+        Args:
+            spacecraft: Spacecraft to download data for. Must be 'SOLAR1' or 'ACE'.
+            instrument: Instrument to download data for. Must be 'mag' or 'plasma'.
+            fetcher: FetchNOAA instance used to perform the download.
+        """
+        super().__init__()
+        self.spacecraft = spacecraft
+        self.instrument = instrument
+        self.fetcher = fetcher
+
+    async def process(self, item: Record, context: dict, **kwargs):
+        self.logger.info(f"Downloading NOAA {self.spacecraft} {self.instrument} data.")
+
+        downloaded = self.fetcher.download_csv(
+            spacecraft=self.spacecraft,  # type: ignore
+            instrument=self.instrument,  # type: ignore
+        )
+
+        if not downloaded:
+            self.logger.info(
+                f"No NOAA {self.spacecraft} {self.instrument} data downloaded."
+            )
+            return
+
+        for file_path, path_handler in downloaded.items():
+            content_date = path_handler.content_date  # type: ignore
+            context[PROGRESS_DATE_CONTEXT_KEY] = content_date
+
+            await self.publish_next(
+                FileRecord(file_path, content_date),
+                context,
+                **kwargs,
+            )

--- a/src/imap_mag/data_pipelines/NOAAPipeline.py
+++ b/src/imap_mag/data_pipelines/NOAAPipeline.py
@@ -1,0 +1,79 @@
+from imap_mag.client.NOAAApiClient import NOAARTSWApiClient
+from imap_mag.config.AppSettings import AppSettings
+from imap_mag.data_pipelines import (
+    AutomaticRunParameters,
+    FetchByDatesRunParameters,
+    Pipeline,
+)
+from imap_mag.data_pipelines.DownloadNOAAStage import DownloadNOAAStage
+from imap_mag.data_pipelines.GetProcessingDatesStage import (
+    DateResolutionMode,
+    GetProcessingDatesStage,
+)
+from imap_mag.data_pipelines.PublishFileToDatastoreStage import (
+    PublishFileToDatastoreStage,
+)
+from imap_mag.data_pipelines.SaveProcessingDatesStage import SaveProcessingDatesStage
+from imap_mag.db import Database
+from imap_mag.download.FetchNOAA import FetchNOAA
+from imap_mag.io import FileFinder
+from imap_mag.util.DatetimeProvider import DatetimeProvider
+
+
+class NOAAPipeline(Pipeline):
+    def __init__(
+        self,
+        spacecraft: str,
+        instrument: str,
+        database: Database | None,
+        settings: AppSettings,
+        datetime_provider: DatetimeProvider = DatetimeProvider(),
+    ):
+        super().__init__(settings=settings, datetime_provider=datetime_provider)
+
+        self.spacecraft = spacecraft
+        self.instrument = instrument
+
+        self.initial_context = {
+            "progress_item_name": f"{spacecraft.upper()}_{instrument.upper()}",
+        }
+
+        self._database = database
+
+        self._client = NOAARTSWApiClient(
+            settings.fetch_solar1_ace.api.url_base,
+        )
+
+        datastore_finder = FileFinder(settings.data_store)
+        work_folder = settings.setup_work_folder_for_command(settings.fetch_solar1_ace)
+
+        self._fetcher = FetchNOAA(
+            data_access=self._client,
+            work_folder=work_folder,
+            datastore_finder=datastore_finder,
+        )
+
+        self._datetime_provider = datetime_provider
+
+    def build(self, run_params: AutomaticRunParameters | FetchByDatesRunParameters):  # type: ignore
+        super().build(
+            run_parameters=run_params,
+            stages=[
+                GetProcessingDatesStage(
+                    database=self._database,
+                    date_resolution_mode=DateResolutionMode.EXACT_DATETIME,
+                    datetime_provider=self._datetime_provider,
+                ),
+                DownloadNOAAStage(
+                    spacecraft=self.spacecraft,
+                    instrument=self.instrument,
+                    fetcher=self._fetcher,
+                ),
+                PublishFileToDatastoreStage(
+                    enabled=self._settings.fetch_solar1_ace.publish_to_data_store,
+                    database=self._database,
+                    settings=self._settings,
+                ),
+                SaveProcessingDatesStage(database=self._database),
+            ],
+        )

--- a/tests/unit/test_DownloadNOAAStage.py
+++ b/tests/unit/test_DownloadNOAAStage.py
@@ -1,0 +1,110 @@
+"""Tests for DownloadNOAAStage."""
+
+import asyncio
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+from imap_mag.data_pipelines import PROGRESS_DATE_CONTEXT_KEY
+from imap_mag.data_pipelines.DownloadNOAAStage import DownloadNOAAStage
+from imap_mag.data_pipelines.Record import FileRecord, Record
+from imap_mag.download.FetchNOAA import FetchNOAA
+
+
+class TestDownloadNOAAStage:
+    def _make_stage(
+        self,
+        spacecraft: str = "SOLAR1",
+        instrument: str = "mag",
+        fetcher: FetchNOAA | None = None,
+    ) -> tuple[DownloadNOAAStage, MagicMock]:
+        mock_fetcher = fetcher or MagicMock(spec=FetchNOAA)
+        stage = DownloadNOAAStage(
+            spacecraft=spacecraft,
+            instrument=instrument,
+            fetcher=mock_fetcher,
+        )
+        stage._next_stage = AsyncMock()
+        stage._index = 0
+        return stage, mock_fetcher
+
+    def test_does_not_publish_when_no_data_downloaded(self) -> None:
+        # Set up.
+        stage, mock_fetcher = self._make_stage()
+        mock_fetcher.download_csv.return_value = {}
+
+        # Exercise.
+        asyncio.run(stage.process(Record("init"), {}))
+
+        # Verify.
+        stage._next_stage.process.assert_not_called()
+
+    def test_calls_download_csv_with_spacecraft_and_instrument(self) -> None:
+        # Set up.
+        stage, mock_fetcher = self._make_stage(spacecraft="ACE", instrument="plasma")
+        mock_fetcher.download_csv.return_value = {}
+
+        # Exercise.
+        asyncio.run(stage.process(Record("init"), {}))
+
+        # Verify.
+        mock_fetcher.download_csv.assert_called_once_with(
+            spacecraft="ACE", instrument="plasma"
+        )
+
+    def test_publishes_file_record_and_sets_progress_date_for_each_downloaded_file(
+        self, tmp_path: Path
+    ) -> None:
+        # Set up.
+        stage, mock_fetcher = self._make_stage()
+
+        content_date = datetime(2026, 7, 21, 9, 0, 0)
+        mock_handler = MagicMock()
+        mock_handler.content_date = content_date
+
+        csv_file = tmp_path / "SOLAR1_mag_noaa_20260721.csv"
+        csv_file.write_bytes(b"time_tag,bx_gsm\n2026-07-21T09:00:00,1.0")
+
+        mock_fetcher.download_csv.return_value = {csv_file: mock_handler}
+
+        context: dict = {}
+
+        # Exercise.
+        asyncio.run(stage.process(Record("init"), context))
+
+        # Verify - one FileRecord published; progress date set from path handler.
+        stage._next_stage.process.assert_called_once()
+        published: FileRecord = stage._next_stage.process.call_args[0][0]
+        assert published.file_path == csv_file
+        assert published.content_date == content_date
+        assert context[PROGRESS_DATE_CONTEXT_KEY] == content_date
+
+    def test_publishes_one_record_per_downloaded_day(self, tmp_path: Path) -> None:
+        # Set up - two files from two different days.
+        stage, mock_fetcher = self._make_stage()
+
+        date1 = datetime(2026, 7, 21, 9, 0, 0)
+        date2 = datetime(2026, 7, 22, 8, 0, 0)
+
+        handler1, handler2 = MagicMock(), MagicMock()
+        handler1.content_date = date1
+        handler2.content_date = date2
+
+        file1 = tmp_path / "SOLAR1_mag_noaa_20260721.csv"
+        file2 = tmp_path / "SOLAR1_mag_noaa_20260722.csv"
+        file1.write_bytes(b"data")
+        file2.write_bytes(b"data")
+
+        mock_fetcher.download_csv.return_value = {file1: handler1, file2: handler2}
+
+        context: dict = {}
+
+        # Exercise.
+        asyncio.run(stage.process(Record("init"), context))
+
+        # Verify - one publish call per file; progress date reflects the last one set.
+        assert stage._next_stage.process.call_count == 2
+        published_records = [
+            call[0][0] for call in stage._next_stage.process.call_args_list
+        ]
+        assert {r.file_path for r in published_records} == {file1, file2}


### PR DESCRIPTION
Mostly copies the iALrt one, just changing the downloader and re-using the other stages.

As the NOAA fetcher always gets the last 24h of data (what the json file contains), I'm not entirely sure if we actually need the `GetProcessingDatesStage`. We don't do any filtering of the downloaded data, after all.

Close #342 
