### PR TITLE
fix: I-ALiRT progress timestamp should track downloaded data, not query window end

### DIFF
--- a/src/imap_mag/data_pipelines/DownloadIALiRTStage.py
+++ b/src/imap_mag/data_pipelines/DownloadIALiRTStage.py
@@ -49,9 +49,11 @@ class DownloadIALiRTStage(Stage):
             )
             return
 
-        # update progress
+        # update progress: use the latest actual data timestamp downloaded, not
+        # the requested end_date, so we don't skip over data on the next run if
+        # the window extends beyond what has actually arrived yet.
         for file_path, path_handler in downloaded.items():
-            context[PROGRESS_DATE_CONTEXT_KEY] = end_date
+            context[PROGRESS_DATE_CONTEXT_KEY] = path_handler.max_record_date
 
             # Stream file to the next stage
             await self.publish_next(

--- a/src/imap_mag/download/FetchIALiRT.py
+++ b/src/imap_mag/download/FetchIALiRT.py
@@ -144,8 +144,10 @@ class FetchIALiRT:
 
                 daily_dates = self.__get_index_as_datetime(daily_data)
                 min_daily_date = min(daily_dates)
+                max_daily_date = max(daily_dates)
 
                 path_handler = path_handler_factory(content_date)
+                path_handler.max_record_date = max_daily_date
 
                 # Find file in datastore
                 file_path: Path | None = self.__datastore_finder.find_by_handler(

--- a/src/imap_mag/io/file/IALiRTPathHandler.py
+++ b/src/imap_mag/io/file/IALiRTPathHandler.py
@@ -23,6 +23,7 @@ class IALiRTPathHandler(IFilePathHandler):
     extension: str = "csv"
     is_hk: bool = False
     is_legacy: bool = False  # if legacy naming
+    max_record_date: datetime | None = None  # latest actual data timestamp downloaded
 
     def supports_sequencing(self) -> bool:
         return False

--- a/tests/integration/test_pollIALiRT.py
+++ b/tests/integration/test_pollIALiRT.py
@@ -29,7 +29,9 @@ TOMORROW = TODAY + timedelta(days=1)
 YESTERDAY = TODAY - timedelta(days=1)
 START_OF_HOUR = NOW.replace(minute=0, second=0, microsecond=0)
 END_OF_HOUR = NOW.replace(minute=59, second=59, microsecond=999999)
-END_OF_TODAY = TODAY.replace(hour=23, minute=59, second=59, microsecond=999999)
+# The mocked I-ALiRT API responses encode timestamps without microseconds, so the
+# actual latest downloaded data record timestamp truncates to whole seconds.
+LATEST_DOWNLOADED_RECORD_TIMESTAMP = END_OF_HOUR.replace(microsecond=0)
 
 
 def define_available_ialirt_mappings(
@@ -213,7 +215,7 @@ async def test_poll_ialirt_first_ever_run_mag(
     verify_available_ialirt(
         database=test_database,
         instrument="mag",
-        expected_progress_timestamp=END_OF_TODAY,
+        expected_progress_timestamp=LATEST_DOWNLOADED_RECORD_TIMESTAMP,
         actual_timestamp=NOW.replace(microsecond=0),
     )
 
@@ -267,7 +269,7 @@ async def test_poll_ialirt_concurrent_multi_instrument(
         verify_available_ialirt(
             database=test_database,
             instrument=inst,
-            expected_progress_timestamp=END_OF_TODAY,
+            expected_progress_timestamp=LATEST_DOWNLOADED_RECORD_TIMESTAMP,
             actual_timestamp=NOW.replace(tzinfo=None),
         )
         assert_file_exists(inst, TODAY)
@@ -331,7 +333,7 @@ async def test_poll_ialirt_continue_from_previous_download(
         verify_available_ialirt(
             database=test_database,
             instrument=inst,
-            expected_progress_timestamp=END_OF_TODAY,
+            expected_progress_timestamp=LATEST_DOWNLOADED_RECORD_TIMESTAMP,
             actual_timestamp=NOW.replace(tzinfo=None),
         )
         assert_file_exists(inst, TODAY)
@@ -447,7 +449,7 @@ async def test_poll_ialirt_hk_first_ever_run(
     verify_available_ialirt(
         database=test_database,
         instrument="mag_hk",
-        expected_progress_timestamp=END_OF_HOUR,
+        expected_progress_timestamp=LATEST_DOWNLOADED_RECORD_TIMESTAMP,
         actual_timestamp=NOW.replace(microsecond=0),
         hk=True,
     )
@@ -502,7 +504,9 @@ async def test_poll_ialirt_specify_start_end_dates_hk(
 
     verify_available_ialirt(
         database=test_database,
-        expected_progress_timestamp=END_OF_HOUR.replace(tzinfo=None),
+        expected_progress_timestamp=LATEST_DOWNLOADED_RECORD_TIMESTAMP.replace(
+            tzinfo=None
+        ),
         actual_timestamp=NOW.replace(microsecond=0).replace(tzinfo=None),
         hk=True,
         instrument="mag_hk",


### PR DESCRIPTION
## Summary

- `progress_timestamp` for I-ALiRT polling was being set to the requested `end_date` of the download window (which defaults to end-of-today for automatic runs) instead of the timestamp of the latest data actually downloaded.
- This meant that if the window extended beyond the data currently available (e.g. polling "up to end of today" when only a few hours of today's data exist), progress would jump ahead to a point in the future. The next poll would then start from that future timestamp and silently skip any data that arrived in between.
- Fixed by having `FetchIALiRT` record the max record timestamp actually seen in each day's downloaded data on the `IALiRTPathHandler`, and having `DownloadIALiRTStage` use that value (instead of `end_date`) when updating progress.

## Test plan

- [x] Updated `tests/integration/test_pollIALiRT.py` expectations to reflect the corrected behaviour (progress now tracks the last downloaded record's timestamp rather than the query window end) — verified against real container-backed wiremock/postgres runs, not just guessed values.
- [x] `poetry run pytest tests/integration/test_pollIALiRT.py -q` — 6 passed, 1 skipped
- [x] `poetry run pytest tests/unit -q -n auto` — 1004 passed
- [x] `poetry run pre-commit run --all-files` on changed files