### PR TITLE
fix: prevent I-ALiRT quicklook plot hang from bogus date-axis autoscale

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 requires-python = ">=3.11,<3.13" # blocked by imap_processing https://github.com/IMAP-Science-Operations-Center/imap_processing/blob/dev/pyproject.toml#L17
 name = "imap-mag"
-version = "6.1.2"
+version = "6.1.3"
 description = "Process IMAP data"
 authors = [
   {name = "alastairtree"},

--- a/src/imap_mag/plot/plot_ialirt_files.py
+++ b/src/imap_mag/plot/plot_ialirt_files.py
@@ -313,15 +313,9 @@ def create_figure(
     output_file = save_folder / f"ialirt_quicklook_{max_date.strftime('%Y%m%d')}.png"
 
     if not ialirt_data.empty:
-        # Matplotlib can mis-autoscale a date axis to a huge, bogus time span
-        # when an axis only has a single data point plotted against a
-        # categorical (e.g. string) y-value (e.g. "Mode" with only one HK
-        # sample). Force every axis back to the real data range so
-        # set_time_format() doesn't try to generate ticks across that bogus
-        # span, which can hang/crash figure rendering.
-        min_date = ialirt_data.index.min().to_pydatetime()
-        for ax in fig.get_axes():
-            ax.set_xlim(mdates.date2num(min_date), mdates.date2num(max_date))
+        _fix_bogus_axis_autoscale(
+            fig, ialirt_data.index.min().to_pydatetime(), max_date
+        )
 
     set_time_format(fig)
     set_figure_title(fig, datetime_provider)
@@ -337,6 +331,30 @@ def create_figure(
             content_date=max_date,
         ),
     )
+
+
+def _fix_bogus_axis_autoscale(
+    fig: plt.Figure, min_date: datetime, max_date: datetime
+) -> None:
+    """Reset axes whose autoscaled x-limits vastly exceed the real data range.
+
+    Matplotlib can mis-autoscale a date axis to a huge, bogus time span when
+    an axis only has a single data point plotted against a categorical (e.g.
+    string) y-value (e.g. "Mode" with only one HK sample). set_time_format()
+    would then try to generate ticks across that bogus span, which can
+    hang/crash figure rendering. Axes that autoscaled sensibly (i.e. within
+    the real data range, plus matplotlib's usual small margin) are left
+    untouched so their normal padding is preserved.
+    """
+    data_min_num = mdates.date2num(min_date)
+    data_max_num = mdates.date2num(max_date)
+    data_span = max(data_max_num - data_min_num, 1 / 24)  # at least 1 hour
+
+    for ax in fig.get_axes():
+        x_lim = ax.get_xlim()
+        axis_span = x_lim[1] - x_lim[0]
+        if axis_span > data_span * 10:
+            ax.set_xlim(data_min_num, data_max_num)
 
 
 def set_time_format(fig: plt.Figure) -> None:

--- a/src/imap_mag/plot/plot_ialirt_files.py
+++ b/src/imap_mag/plot/plot_ialirt_files.py
@@ -312,6 +312,17 @@ def create_figure(
     )
     output_file = save_folder / f"ialirt_quicklook_{max_date.strftime('%Y%m%d')}.png"
 
+    if not ialirt_data.empty:
+        # Matplotlib can mis-autoscale a date axis to a huge, bogus time span
+        # when an axis only has a single data point plotted against a
+        # categorical (e.g. string) y-value (e.g. "Mode" with only one HK
+        # sample). Force every axis back to the real data range so
+        # set_time_format() doesn't try to generate ticks across that bogus
+        # span, which can hang/crash figure rendering.
+        min_date = ialirt_data.index.min().to_pydatetime()
+        for ax in fig.get_axes():
+            ax.set_xlim(mdates.date2num(min_date), mdates.date2num(max_date))
+
     set_time_format(fig)
     set_figure_title(fig, datetime_provider)
 

--- a/tests/unit/test_plot_ialirt_files.py
+++ b/tests/unit/test_plot_ialirt_files.py
@@ -238,6 +238,46 @@ class TestCreateFigureFunction:
         assert output_file.exists()
         assert handler is not None
 
+    def test_does_not_hang_with_single_categorical_hk_sample(self, tmp_path):
+        """Regression test: a single HK sample (e.g. one mag_hk_mode string
+        value, as happens when science data updates far more often than HK
+        data) made matplotlib mis-autoscale the date axis to a huge, bogus
+        time span. set_time_format() then tried to generate thousands of
+        ticks for that span, hanging/crashing figure rendering."""
+        from unittest.mock import MagicMock, patch
+
+        idx = pd.date_range("2025-10-17", periods=3, freq="1min", tz="UTC")
+        df = pd.DataFrame(
+            {col: [float(i) for i in range(3)] for col in _IALIRT_COLUMNS},
+            index=idx,
+        )
+        # Only one HK sample has a mode value; everywhere else it's NaN
+        # (dtype becomes object, mixing NaN with a single string "Burst").
+        df["mag_hk_mode"] = [None, "Burst", None]
+
+        mock_db = MagicMock()
+        mock_db.get_workflow_progress.return_value.get_progress_timestamp.return_value = None
+        mock_db.get_workflow_progress.return_value.get_last_checked_date.return_value = None
+
+        with (
+            patch(
+                "imap_mag.plot.plot_ialirt_files.Database",
+                return_value=mock_db,
+            ),
+            patch("imap_mag.plot.plot_ialirt_files.plt.close"),
+        ):
+            output_file, _handler = create_figure(df, tmp_path)
+            fig = plt.gcf()
+
+        assert output_file.exists()
+
+        mode_axis = next(ax for ax in fig.get_axes() if ax.get_title() == "Mode")
+        x_lim = mode_axis.get_xlim()
+        time_span_hours = (x_lim[1] - x_lim[0]) * 24
+        assert time_span_hours < 1
+
+        plt.close(fig)
+
 
 class TestSetTimeFormatFunction:
     def test_applies_time_formatter_to_figure_axes(self):


### PR DESCRIPTION
## Summary
- Fixes a hang/crash (SIGKILL, exceeding memory) in the I-ALiRT quicklook plot when a single HK sample is plotted against a categorical column (e.g. `mag_hk_mode`). Matplotlib mis-autoscales the date axis to a bogus multi-year span in that case, and the tick locator then tries to generate thousands of ticks, hanging the process.
- Fix: after all subplots are drawn, force every axis's x-limits back to the real data time range (`ialirt_data.index.min()`/`.max()`) before `set_time_format()` picks a tick locator.
- Bumped version to 6.1.3 for release.

## Test plan
- [x] Added a fast (~1s) regression test (`test_does_not_hang_with_single_categorical_hk_sample`) using a minimal synthetic dataset (3 rows, one HK mode string value) that reproduces the hang without the fix (verified it times out on the unpatched code) and passes with the fix.
- [x] `poetry run pytest tests/unit/test_plot_ialirt_files.py` — 14 passed
- [x] `poetry run pytest tests/unit` — 1005 passed
- [x] `poetry run pre-commit run --all-files` on changed files — passed