### PR TITLE
feat: publish calculated spin-plane offsets to the datastore

### DIFF
--- a/src/imap_mag/cli/calibrate.py
+++ b/src/imap_mag/cli/calibrate.py
@@ -15,7 +15,10 @@ from imap_mag.config import (
 )
 from imap_mag.db.Database import Database
 from imap_mag.io import DatastoreFileManager, FileFinder
-from imap_mag.io.file import CalibrationLayerPathHandler
+from imap_mag.io.file import (
+    CalculatedOffsetsPathHandler,
+    CalibrationLayerPathHandler,
+)
 from imap_mag.util import ScienceMode
 from mag_toolkit.calibration import (
     CalibrationJob,
@@ -276,8 +279,46 @@ def _calibrate_for_date(
         data_path, path_handler=calibration_handler.get_equivalent_data_handler()
     )
 
+    # Publish any calculated spin-plane offsets the calibration wrote to the work
+    # folder, comparing against the datastore and upversioning when they differ.
+    _publish_calculated_offsets(
+        getattr(calibrator, "written_offset_files", []),
+        outputManager,
+        FileFinder(settings_for_output.data_store),
+    )
+
     logger.info(
         f"Calibration complete for {start_date.strftime('%Y-%m-%d')} ({mode.value}) written to {output_calibration_path!s}."
     )
 
     return output_calibration_path
+
+
+def _publish_calculated_offsets(
+    offset_files: list[Path],
+    output_manager,
+    offsets_finder: FileFinder,
+) -> None:
+    """Publish calculated spin-plane offset CSVs to the datastore.
+
+    Each file is versioned relative to the latest existing offsets for the same
+    sensor/date/offset-type: ``add_file`` reuses that version when the content is
+    identical (hash match) and upversions when it differs, indexing the result in
+    the database when the output manager is database-backed.
+    """
+    for offset_file in offset_files:
+        offset_handler = CalculatedOffsetsPathHandler.from_work_folder_file(offset_file)
+
+        latest = offsets_finder.find_latest_version_by_handler(
+            offset_handler, throw_if_not_found=False
+        )
+        if latest is not None:
+            existing = CalculatedOffsetsPathHandler.from_filename(latest.name)
+            offset_handler.version = existing.version if existing else 1
+        else:
+            offset_handler.version = 1
+
+        (published_offset_path, _) = output_manager.add_file(
+            offset_file, path_handler=offset_handler
+        )
+        logger.info(f"Published calculated offsets to {published_offset_path!s}.")

--- a/src/imap_mag/io/file/CalculatedOffsetsPathHandler.py
+++ b/src/imap_mag/io/file/CalculatedOffsetsPathHandler.py
@@ -3,7 +3,6 @@ import re
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import ClassVar
 
 from imap_mag.io.file.VersionedPathHandler import VersionedPathHandler
 
@@ -15,6 +14,14 @@ SPIN_PLANE = "spin_plane"  # spin-averaged offsets
 SPIN_OPTIMISED = "spin_optimised"  # spin-tone-corrected ("optimised") offsets
 OFFSET_TYPES = (SPIN_PLANE, SPIN_OPTIMISED)
 
+# Each offset type has its own file-name descriptor so the two products are uniquely
+# named (and not just distinguished by their folder). This mirrors what MATLAB writes.
+_DESCRIPTOR_BY_OFFSET_TYPE = {
+    SPIN_PLANE: "spin-plane-offsets",
+    SPIN_OPTIMISED: "spin-plane-optimised-offsets",
+}
+_OFFSET_TYPE_BY_DESCRIPTOR = {v: k for k, v in _DESCRIPTOR_BY_OFFSET_TYPE.items()}
+
 
 @dataclass
 class CalculatedOffsetsPathHandler(VersionedPathHandler):
@@ -22,11 +29,11 @@ class CalculatedOffsetsPathHandler(VersionedPathHandler):
 
     These live in ``calibration/calculated_offsets/<offset_type>/`` where
     ``offset_type`` is ``spin_plane`` (spin-averaged offsets) or ``spin_optimised``
-    (spin-tone-corrected offsets). The scripted-L2 MATLAB calibration writes one CSV
-    per sensor per day into each folder. The file name is identical in both folders,
-    so the folder (``offset_type``) is what distinguishes the two products.
+    (spin-tone-corrected offsets). Each offset type has a distinct file-name
+    descriptor so the two products are uniquely named:
 
-    File names look like ``imap_mag_mago-spin-plane-offsets_20260114_v024.csv``.
+    - ``spin_plane``     -> ``imap_mag_<sensor>-spin-plane-offsets_<date>_vNNN.csv``
+    - ``spin_optimised`` -> ``imap_mag_<sensor>-spin-plane-optimised-offsets_<date>_vNNN.csv``
     """
 
     mission: str = "imap"
@@ -36,7 +43,16 @@ class CalculatedOffsetsPathHandler(VersionedPathHandler):
     content_date: datetime | None = None  # date the offsets belong to
     extension: str = "csv"
 
-    DESCRIPTOR: ClassVar[str] = "spin-plane-offsets"
+    def _descriptor(self) -> str:
+        super()._check_property_values("descriptor", ["offset_type"])
+        assert self.offset_type
+
+        if self.offset_type not in _DESCRIPTOR_BY_OFFSET_TYPE:
+            raise ValueError(
+                f"Unknown offset_type '{self.offset_type}'. Expected one of "
+                f"{OFFSET_TYPES}."
+            )
+        return _DESCRIPTOR_BY_OFFSET_TYPE[self.offset_type]
 
     def get_content_date_for_indexing(self) -> datetime | None:
         return self.content_date
@@ -50,21 +66,25 @@ class CalculatedOffsetsPathHandler(VersionedPathHandler):
         ).as_posix()
 
     def get_filename(self) -> str:
-        super()._check_property_values("file name", ["sensor", "content_date"])
+        super()._check_property_values(
+            "file name", ["sensor", "offset_type", "content_date"]
+        )
         assert self.sensor and self.content_date
 
         return (
-            f"{self.mission}_{self.instrument}_{self.sensor}-{self.DESCRIPTOR}_"
+            f"{self.mission}_{self.instrument}_{self.sensor}-{self._descriptor()}_"
             f"{self.content_date.strftime('%Y%m%d')}_v{self.version:03d}.{self.extension}"
         )
 
     def get_unsequenced_pattern(self) -> re.Pattern:
-        super()._check_property_values("pattern", ["sensor", "content_date"])
+        super()._check_property_values(
+            "pattern", ["sensor", "offset_type", "content_date"]
+        )
         assert self.sensor and self.content_date
 
         return re.compile(
             rf"{self.mission}_{self.instrument}_{re.escape(self.sensor)}-"
-            rf"{re.escape(self.DESCRIPTOR)}_{self.content_date.strftime('%Y%m%d')}"
+            rf"{re.escape(self._descriptor())}_{self.content_date.strftime('%Y%m%d')}"
             rf"_v(?P<version>\d+)\.{self.extension}"
         )
 
@@ -74,12 +94,14 @@ class CalculatedOffsetsPathHandler(VersionedPathHandler):
     ) -> "CalculatedOffsetsPathHandler | None":
         """Instantiate from a file name.
 
-        The name alone cannot tell ``spin_plane`` from ``spin_optimised`` (both use
-        identical names in different folders), so ``offset_type`` is left unset. Use
-        :meth:`from_work_folder_file` when the containing folder is known.
+        The descriptor uniquely identifies the offset type, so ``offset_type`` is set
+        (``spin-plane-optimised-offsets`` -> ``spin_optimised``, ``spin-plane-offsets``
+        -> ``spin_plane``).
         """
+        # Match the more specific (optimised) descriptor first.
+        descriptors = "|".join(re.escape(d) for d in _OFFSET_TYPE_BY_DESCRIPTOR)
         match = re.match(
-            rf"imap_mag_(?P<sensor>mago|magi)-{re.escape(cls.DESCRIPTOR)}_"
+            rf"imap_mag_(?P<sensor>mago|magi)-(?P<descr>{descriptors})_"
             r"(?P<date>\d{8})_v(?P<version>\d+)\.(?P<ext>\w+)",
             Path(filename).name,
         )
@@ -92,6 +114,7 @@ class CalculatedOffsetsPathHandler(VersionedPathHandler):
 
         return cls(
             sensor=match["sensor"],
+            offset_type=_OFFSET_TYPE_BY_DESCRIPTOR[match["descr"]],
             content_date=datetime.strptime(match["date"], "%Y%m%d"),
             version=int(match["version"]),
             extension=match["ext"],
@@ -101,8 +124,9 @@ class CalculatedOffsetsPathHandler(VersionedPathHandler):
     def from_work_folder_file(cls, file: Path) -> "CalculatedOffsetsPathHandler":
         """Build a handler for a MATLAB-produced offsets CSV in the work folder.
 
-        ``offset_type`` is taken from the immediate parent folder name (``spin_plane``
-        or ``spin_optimised``); the remaining fields are parsed from the file name.
+        The offset type is derived from the file name; the immediate parent folder
+        (``spin_plane`` / ``spin_optimised``) is cross-checked against it as a guard
+        against a misplaced file.
         """
         handler = cls.from_filename(file.name)
         if handler is None:
@@ -110,12 +134,16 @@ class CalculatedOffsetsPathHandler(VersionedPathHandler):
                 f"'{file.name}' is not a recognised calculated-offsets file name."
             )
 
-        offset_type = file.parent.name
-        if offset_type not in OFFSET_TYPES:
+        folder = file.parent.name
+        if folder not in OFFSET_TYPES:
             raise ValueError(
                 f"Offsets file {file} must live in one of {OFFSET_TYPES} folders, "
-                f"got '{offset_type}'."
+                f"got '{folder}'."
+            )
+        if handler.offset_type != folder:
+            raise ValueError(
+                f"Offsets file {file} name implies offset type "
+                f"'{handler.offset_type}' but it sits in the '{folder}' folder."
             )
 
-        handler.offset_type = offset_type
         return handler

--- a/src/imap_mag/io/file/CalculatedOffsetsPathHandler.py
+++ b/src/imap_mag/io/file/CalculatedOffsetsPathHandler.py
@@ -1,0 +1,121 @@
+import logging
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import ClassVar
+
+from imap_mag.io.file.VersionedPathHandler import VersionedPathHandler
+
+logger = logging.getLogger(__name__)
+
+# The two datastore sub-folders (under calibration/calculated_offsets) that hold the
+# per-day spin-plane offset CSVs produced by the scripted-L2 MATLAB calibration.
+SPIN_PLANE = "spin_plane"  # spin-averaged offsets
+SPIN_OPTIMISED = "spin_optimised"  # spin-tone-corrected ("optimised") offsets
+OFFSET_TYPES = (SPIN_PLANE, SPIN_OPTIMISED)
+
+
+@dataclass
+class CalculatedOffsetsPathHandler(VersionedPathHandler):
+    """Path handler for calculated spin-plane offset CSVs.
+
+    These live in ``calibration/calculated_offsets/<offset_type>/`` where
+    ``offset_type`` is ``spin_plane`` (spin-averaged offsets) or ``spin_optimised``
+    (spin-tone-corrected offsets). The scripted-L2 MATLAB calibration writes one CSV
+    per sensor per day into each folder. The file name is identical in both folders,
+    so the folder (``offset_type``) is what distinguishes the two products.
+
+    File names look like ``imap_mag_mago-spin-plane-offsets_20260114_v024.csv``.
+    """
+
+    mission: str = "imap"
+    instrument: str = "mag"
+    sensor: str | None = None  # "mago" or "magi"
+    offset_type: str | None = None  # one of OFFSET_TYPES
+    content_date: datetime | None = None  # date the offsets belong to
+    extension: str = "csv"
+
+    DESCRIPTOR: ClassVar[str] = "spin-plane-offsets"
+
+    def get_content_date_for_indexing(self) -> datetime | None:
+        return self.content_date
+
+    def get_folder_structure(self) -> str:
+        super()._check_property_values("folder structure", ["offset_type"])
+        assert self.offset_type
+
+        return (
+            Path("calibration") / "calculated_offsets" / self.offset_type
+        ).as_posix()
+
+    def get_filename(self) -> str:
+        super()._check_property_values("file name", ["sensor", "content_date"])
+        assert self.sensor and self.content_date
+
+        return (
+            f"{self.mission}_{self.instrument}_{self.sensor}-{self.DESCRIPTOR}_"
+            f"{self.content_date.strftime('%Y%m%d')}_v{self.version:03d}.{self.extension}"
+        )
+
+    def get_unsequenced_pattern(self) -> re.Pattern:
+        super()._check_property_values("pattern", ["sensor", "content_date"])
+        assert self.sensor and self.content_date
+
+        return re.compile(
+            rf"{self.mission}_{self.instrument}_{re.escape(self.sensor)}-"
+            rf"{re.escape(self.DESCRIPTOR)}_{self.content_date.strftime('%Y%m%d')}"
+            rf"_v(?P<version>\d+)\.{self.extension}"
+        )
+
+    @classmethod
+    def from_filename(
+        cls, filename: str | Path
+    ) -> "CalculatedOffsetsPathHandler | None":
+        """Instantiate from a file name.
+
+        The name alone cannot tell ``spin_plane`` from ``spin_optimised`` (both use
+        identical names in different folders), so ``offset_type`` is left unset. Use
+        :meth:`from_work_folder_file` when the containing folder is known.
+        """
+        match = re.match(
+            rf"imap_mag_(?P<sensor>mago|magi)-{re.escape(cls.DESCRIPTOR)}_"
+            r"(?P<date>\d{8})_v(?P<version>\d+)\.(?P<ext>\w+)",
+            Path(filename).name,
+        )
+        logger.debug(
+            f"Filename {filename} matches {match.groupdict(0) if match else 'nothing'} with calculated-offsets regex."
+        )
+
+        if match is None:
+            return None
+
+        return cls(
+            sensor=match["sensor"],
+            content_date=datetime.strptime(match["date"], "%Y%m%d"),
+            version=int(match["version"]),
+            extension=match["ext"],
+        )
+
+    @classmethod
+    def from_work_folder_file(cls, file: Path) -> "CalculatedOffsetsPathHandler":
+        """Build a handler for a MATLAB-produced offsets CSV in the work folder.
+
+        ``offset_type`` is taken from the immediate parent folder name (``spin_plane``
+        or ``spin_optimised``); the remaining fields are parsed from the file name.
+        """
+        handler = cls.from_filename(file.name)
+        if handler is None:
+            raise ValueError(
+                f"'{file.name}' is not a recognised calculated-offsets file name."
+            )
+
+        offset_type = file.parent.name
+        if offset_type not in OFFSET_TYPES:
+            raise ValueError(
+                f"Offsets file {file} must live in one of {OFFSET_TYPES} folders, "
+                f"got '{offset_type}'."
+            )
+
+        handler.offset_type = offset_type
+        return handler

--- a/src/imap_mag/io/file/__init__.py
+++ b/src/imap_mag/io/file/__init__.py
@@ -1,4 +1,7 @@
 from imap_mag.io.file.AncillaryPathHandler import AncillaryPathHandler
+from imap_mag.io.file.CalculatedOffsetsPathHandler import (
+    CalculatedOffsetsPathHandler,
+)
 from imap_mag.io.file.CalibrationLayerPathHandler import (
     CalibrationLayerPathHandler,
 )
@@ -20,6 +23,7 @@ from imap_mag.io.file.VersionedPathHandler import VersionedPathHandler
 
 __all__ = [
     "AncillaryPathHandler",
+    "CalculatedOffsetsPathHandler",
     "CalibrationLayerPathHandler",
     "HKBinaryPathHandler",
     "HKDecodedPathHandler",

--- a/src/mag_toolkit/calibration/CalibrationConfig.py
+++ b/src/mag_toolkit/calibration/CalibrationConfig.py
@@ -58,6 +58,20 @@ class ScriptedL2CalibrationConfig(CalibrationConfig):
     input_json_file: str
     datastore_access_mode: DatastoreAccessMode = DatastoreAccessMode.READ_DIRECTLY
     matlab_repo: str
+    write_offsets: Annotated[
+        bool,
+        Field(
+            json_schema_extra={
+                "title": "Write offsets",
+                "description": (
+                    "If true, the calculated spin-plane offsets are written to the "
+                    "work folder and published to calibration/calculated_offsets in "
+                    "the datastore (upversioned when the content differs). Only "
+                    "norm-mode / SPINOPTIMISE configurations actually produce offsets."
+                ),
+            },
+        ),
+    ] = False
 
     @classmethod
     def get_method(cls) -> CalibrationMethod:

--- a/src/mag_toolkit/calibration/CalibrationConfig.py
+++ b/src/mag_toolkit/calibration/CalibrationConfig.py
@@ -67,7 +67,7 @@ class ScriptedL2CalibrationConfig(CalibrationConfig):
                     "If true, the calculated spin-plane offsets are written to the "
                     "work folder and published to calibration/calculated_offsets in "
                     "the datastore (upversioned when the content differs). Only "
-                    "norm-mode / SPINOPTIMISE configurations actually produce offsets."
+                    "SPINOPTIMISE configurations actually produce offsets."
                 ),
             },
         ),

--- a/src/mag_toolkit/calibration/calibrators/ScriptedL2Calibration.py
+++ b/src/mag_toolkit/calibration/calibrators/ScriptedL2Calibration.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from imap_mag.config import AppSettings
 from imap_mag.io.file import CalibrationLayerPathHandler
+from imap_mag.io.file.CalculatedOffsetsPathHandler import OFFSET_TYPES
 from imap_mag.io.file.SPICEPathHandler import SPICEPathHandler
 from imap_mag.util import ScienceMode
 from mag_toolkit.calibration import CalibrationJobParameters
@@ -30,6 +31,11 @@ USER_CONFIG_FILENAME = "imap_mag_scripted_l2_file_path_config.json"
 # Folder (inside the work folder) that holds the sparse datastore copy when using
 # DatastoreAccessMode.LOCAL_WORK_FOLDER_COPY.
 SPARSE_DATASTORE_FOLDER_NAME = "sparse_datastore"
+
+# Folder (inside the work folder) MATLAB writes the calculated spin-plane offsets to
+# when write_offsets is enabled. Mirrors the calibration/calculated_offsets datastore
+# layout: one CSV per sensor per day under each OFFSET_TYPES sub-folder.
+OFFSETS_FOLDER_NAME = "offsets"
 
 # Relative path (within the MATLAB repo) of the script we invoke. Used to fail fast
 # if the acquired repo does not actually contain the expected entry point.
@@ -72,6 +78,9 @@ class ScriptedL2CalibrationJob(CalibrationJob):
         self.name = CalibrationMethod.SCRIPTED_L2_CALIBRATION
         self.app_settings = app_settings
         self.metakernel = metakernel
+        # Calculated spin-plane offset CSVs written to the work folder by the last
+        # run (empty unless write_offsets was enabled and MATLAB produced offsets).
+        self.written_offset_files: list[Path] = []
 
     @staticmethod
     def _work_folder_context(
@@ -130,6 +139,13 @@ class ScriptedL2CalibrationJob(CalibrationJob):
         user_config_path = self._write_user_config(matlab_datastore)
         self._paths_needing_cleanup.append(user_config_path)
 
+        # MATLAB writes offsets into pre-existing sub-folders, so create them upfront.
+        if config.write_offsets:
+            for offset_type in OFFSET_TYPES:
+                (self.work_folder / OFFSETS_FOLDER_NAME / offset_type).mkdir(
+                    parents=True, exist_ok=True
+                )
+
         command = self._build_matlab_command(
             date=date,
             calibration_matrix_version=config.calibration_matrix_version,
@@ -140,6 +156,7 @@ class ScriptedL2CalibrationJob(CalibrationJob):
             matlab_mode=str(mode.value),
             output_layer_filename=output_layer_filename,
             output_data_filename=output_data_filename,
+            write_offsets=config.write_offsets,
         )
 
         call_matlab(
@@ -148,6 +165,8 @@ class ScriptedL2CalibrationJob(CalibrationJob):
             include_project_paths=False,
             timeout=self._timeout_seconds(mode),
         )
+
+        self.written_offset_files = self._collect_offset_files(config.write_offsets)
 
         calfile = self.work_folder / cal_handler.get_filename()
         datafile = (
@@ -164,6 +183,29 @@ class ScriptedL2CalibrationJob(CalibrationJob):
             )
 
         return calfile, datafile
+
+    def _collect_offset_files(self, write_offsets: bool) -> list[Path]:
+        """Return the calculated spin-plane offset CSVs MATLAB wrote to the work folder.
+
+        One CSV per sensor per day is expected under each offsets sub-folder. Only
+        SPINOPTIMISE (norm-mode) configurations actually produce offsets, so an empty
+        result when ``write_offsets`` is set is a warning rather than an error.
+        """
+        if not write_offsets:
+            return []
+
+        offsets_root = self.work_folder / OFFSETS_FOLDER_NAME
+        offset_files: list[Path] = []
+        for offset_type in OFFSET_TYPES:
+            offset_files.extend(sorted((offsets_root / offset_type).glob("*.csv")))
+
+        if not offset_files:
+            logger.warning(
+                f"write_offsets was requested but MATLAB produced no offset CSVs in "
+                f"{offsets_root}. The configuration may not be a SPINOPTIMISE one."
+            )
+
+        return offset_files
 
     def _timeout_seconds(self, mode: ScienceMode) -> int:
         """MATLAB timeout for a single day of the given mode.
@@ -249,8 +291,9 @@ class ScriptedL2CalibrationJob(CalibrationJob):
 
         ``sharepoint_flight_data`` and ``spice_metakernal_root`` point at the
         datastore root MATLAB should read (the real datastore, or the sparse copy),
-        while the three output folders map to the work folder so MATLAB writes there
-        rather than into the datastore.
+        while the output folders map to the work folder so MATLAB writes there
+        rather than into the datastore. ``output_offsets_folder`` is where the
+        (optional) calculated spin-plane offset CSVs are written.
         """
         datastore_path = Path(matlab_datastore).resolve()
         work_folder_path = str(self.work_folder.resolve())
@@ -261,6 +304,9 @@ class ScriptedL2CalibrationJob(CalibrationJob):
             "l2_pre_calibration_outputs": work_folder_path,
             "report_folder": str(datastore_path / "calibration" / "reports"),
             "output_layers_folder": work_folder_path,
+            "output_offsets_folder": str(
+                (self.work_folder / OFFSETS_FOLDER_NAME).resolve()
+            ),
         }
 
         user_config_path = self.work_folder / USER_CONFIG_FILENAME
@@ -284,6 +330,7 @@ class ScriptedL2CalibrationJob(CalibrationJob):
         matlab_mode: str,
         output_layer_filename: str,
         output_data_filename: str,
+        write_offsets: bool = False,
     ) -> str:
         """Build the ``calibrate_l2_offsets`` MATLAB command for a single day.
 
@@ -302,8 +349,11 @@ class ScriptedL2CalibrationJob(CalibrationJob):
                 imap-pipeline-core controls the major/minor versioned name.
             output_data_filename: Bare filename the companion layer-data CSV must be
                 written as (paired with ``output_layer_filename``).
+            write_offsets: Whether MATLAB should write the calculated spin-plane
+                offset CSVs into ``output_offsets_folder`` (norm/SPINOPTIMISE only).
         """
         date_expr = f"datetime({date.year},{date.month},{date.day})"
+        write_offsets_expr = "true" if write_offsets else "false"
 
         return (
             "calibration.scripts.calibrate_l2_offsets("
@@ -316,5 +366,6 @@ class ScriptedL2CalibrationJob(CalibrationJob):
             f'modes=["{matlab_mode}"], '
             f'output_layer_filename="{output_layer_filename}", '
             f'output_data_filename="{output_data_filename}", '
+            f"write_offsets={write_offsets_expr}, "
             "publish_to_sharepoint=false,display_plots=false,spice_transform_and_write=false)"
         )

--- a/tests/integration/test_DBIndexedDatastoreFileManager.py
+++ b/tests/integration/test_DBIndexedDatastoreFileManager.py
@@ -24,6 +24,7 @@ from imap_mag.io import (
 )
 from imap_mag.io.file import (
     AncillaryPathHandler,
+    CalculatedOffsetsPathHandler,
     CalibrationLayerPathHandler,
     HKBinaryPathHandler,
     HKDecodedPathHandler,
@@ -70,6 +71,54 @@ def check_inserted_file(
     assert file.creation_date == datetime.fromtimestamp(test_file.stat().st_ctime)
     assert file.deletion_date is None
     assert file.software_version == __version__
+
+
+def test_DBIndexedDatastoreFileManager_indexes_calculated_offsets(
+    mock_datastore_manager: mock.Mock,
+    mock_database: mock.Mock,
+) -> None:
+    """A calculated-offsets CSV is indexed into the database with correct metadata."""
+    database_manager = DBIndexedDatastoreFileManager(
+        mock_datastore_manager, mock_database
+    )
+
+    original_file = create_test_file(
+        Path(tempfile.gettempdir()) / "offsets_src.csv", "offset content"
+    )
+    path_handler = CalculatedOffsetsPathHandler(
+        sensor="mago",
+        offset_type="spin_plane",
+        content_date=datetime(2026, 1, 14),
+        version=24,
+    )
+
+    # Nothing pre-existing in the database -> treated as a new version.
+    mock_database.get_files.return_value = []
+
+    # The inner (mock) manager "writes" the file at its full datastore path.
+    test_file = Path(tempfile.gettempdir()) / path_handler.get_full_path()
+    test_file.parent.mkdir(parents=True, exist_ok=True)
+
+    def add_side_effect(src, handler):
+        create_test_file(test_file, "offset content")
+        return (test_file, handler)
+
+    mock_datastore_manager.add_file.side_effect = add_side_effect
+
+    captured: dict = {}
+    mock_database.upsert_file.side_effect = lambda file: captured.update(file=file)
+
+    database_manager.add_file(original_file, path_handler)
+
+    indexed = captured["file"]
+    assert indexed.name == "imap_mag_mago-spin-plane-offsets_20260114_v024.csv"
+    assert indexed.version == 24
+    assert indexed.version_major == 0
+    assert indexed.hash == hashlib.md5(b"offset content").hexdigest()
+    assert indexed.content_date == datetime(2026, 1, 14)
+    assert "calibration/calculated_offsets/spin_plane" in indexed.path.replace(
+        "\\", "/"
+    )
 
 
 def test_DBIndexedDatastoreFileManager_writes_to_database(

--- a/tests/unit/test_CalculatedOffsetsPathHandler.py
+++ b/tests/unit/test_CalculatedOffsetsPathHandler.py
@@ -1,0 +1,129 @@
+"""Tests for CalculatedOffsetsPathHandler."""
+
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from imap_mag.io.file.CalculatedOffsetsPathHandler import (
+    SPIN_OPTIMISED,
+    SPIN_PLANE,
+    CalculatedOffsetsPathHandler,
+)
+
+DATE = datetime(2026, 1, 14)
+
+
+def _handler(
+    sensor: str = "mago",
+    offset_type: str = SPIN_PLANE,
+    version: int = 24,
+) -> CalculatedOffsetsPathHandler:
+    return CalculatedOffsetsPathHandler(
+        sensor=sensor,
+        offset_type=offset_type,
+        content_date=DATE,
+        version=version,
+    )
+
+
+class TestCalculatedOffsetsPathHandler:
+    def test_folder_structure_per_offset_type(self):
+        assert (
+            _handler(offset_type=SPIN_PLANE).get_folder_structure()
+            == "calibration/calculated_offsets/spin_plane"
+        )
+        assert (
+            _handler(offset_type=SPIN_OPTIMISED).get_folder_structure()
+            == "calibration/calculated_offsets/spin_optimised"
+        )
+
+    def test_filename(self):
+        assert (
+            _handler(sensor="magi", version=3).get_filename()
+            == "imap_mag_magi-spin-plane-offsets_20260114_v003.csv"
+        )
+
+    def test_full_path(self):
+        assert _handler(version=24).get_full_path(Path("/store")) == Path(
+            "/store/calibration/calculated_offsets/spin_plane/"
+            "imap_mag_mago-spin-plane-offsets_20260114_v024.csv"
+        )
+
+    def test_filename_and_folder_identical_across_offset_types(self):
+        # Both folders hold identically-named files; only the folder differs.
+        plane = _handler(offset_type=SPIN_PLANE)
+        optimised = _handler(offset_type=SPIN_OPTIMISED)
+        assert plane.get_filename() == optimised.get_filename()
+        assert plane.get_folder_structure() != optimised.get_folder_structure()
+
+    def test_supports_sequencing_and_bumps_version(self):
+        handler = _handler(version=24)
+        assert handler.supports_sequencing() is True
+        handler.increase_sequence()
+        assert handler.version == 25
+        assert "_v025.csv" in handler.get_filename()
+
+    def test_unsequenced_pattern_matches_all_versions(self):
+        pattern = _handler().get_unsequenced_pattern()
+        m = pattern.search("imap_mag_mago-spin-plane-offsets_20260114_v024.csv")
+        assert m is not None
+        assert m.group("version") == "024"
+        # Different sensor / date must not match.
+        assert (
+            pattern.search("imap_mag_magi-spin-plane-offsets_20260114_v024.csv") is None
+        )
+        assert (
+            pattern.search("imap_mag_mago-spin-plane-offsets_20260115_v024.csv") is None
+        )
+
+    def test_from_filename_roundtrip(self):
+        handler = CalculatedOffsetsPathHandler.from_filename(
+            "imap_mag_magi-spin-plane-offsets_20260114_v007.csv"
+        )
+        assert handler is not None
+        assert handler.sensor == "magi"
+        assert handler.content_date == DATE
+        assert handler.version == 7
+        # offset_type is unknowable from the name alone.
+        assert handler.offset_type is None
+
+    def test_from_filename_rejects_unrelated_names(self):
+        assert CalculatedOffsetsPathHandler.from_filename("something_else.csv") is None
+        assert (
+            CalculatedOffsetsPathHandler.from_filename(
+                "imap_mag_l2-norm-offsets_20260114_v001.cdf"
+            )
+            is None
+        )
+
+    def test_from_work_folder_file_infers_offset_type_from_parent(self, tmp_path):
+        f = (
+            tmp_path
+            / SPIN_OPTIMISED
+            / "imap_mag_mago-spin-plane-offsets_20260114_v000.csv"
+        )
+        f.parent.mkdir(parents=True)
+        f.write_text("data")
+
+        handler = CalculatedOffsetsPathHandler.from_work_folder_file(f)
+        assert handler.offset_type == SPIN_OPTIMISED
+        assert handler.sensor == "mago"
+        assert handler.content_date == DATE
+        assert handler.get_folder_structure() == (
+            "calibration/calculated_offsets/spin_optimised"
+        )
+
+    def test_from_work_folder_file_rejects_bad_folder(self, tmp_path):
+        f = tmp_path / "wrong" / "imap_mag_mago-spin-plane-offsets_20260114_v000.csv"
+        f.parent.mkdir(parents=True)
+        f.write_text("data")
+        with pytest.raises(ValueError, match="must live in one of"):
+            CalculatedOffsetsPathHandler.from_work_folder_file(f)
+
+    def test_from_work_folder_file_rejects_bad_name(self, tmp_path):
+        f = tmp_path / SPIN_PLANE / "not-an-offsets-file.csv"
+        f.parent.mkdir(parents=True)
+        f.write_text("data")
+        with pytest.raises(ValueError, match="not a recognised"):
+            CalculatedOffsetsPathHandler.from_work_folder_file(f)

--- a/tests/unit/test_CalculatedOffsetsPathHandler.py
+++ b/tests/unit/test_CalculatedOffsetsPathHandler.py
@@ -38,10 +38,18 @@ class TestCalculatedOffsetsPathHandler:
             == "calibration/calculated_offsets/spin_optimised"
         )
 
-    def test_filename(self):
+    def test_filename_spin_plane(self):
         assert (
-            _handler(sensor="magi", version=3).get_filename()
+            _handler(sensor="magi", offset_type=SPIN_PLANE, version=3).get_filename()
             == "imap_mag_magi-spin-plane-offsets_20260114_v003.csv"
+        )
+
+    def test_filename_spin_optimised(self):
+        assert (
+            _handler(
+                sensor="magi", offset_type=SPIN_OPTIMISED, version=3
+            ).get_filename()
+            == "imap_mag_magi-spin-plane-optimised-offsets_20260114_v003.csv"
         )
 
     def test_full_path(self):
@@ -50,11 +58,13 @@ class TestCalculatedOffsetsPathHandler:
             "imap_mag_mago-spin-plane-offsets_20260114_v024.csv"
         )
 
-    def test_filename_and_folder_identical_across_offset_types(self):
-        # Both folders hold identically-named files; only the folder differs.
+    def test_filename_is_unique_across_offset_types(self):
+        # The two products have distinct names as well as distinct folders.
         plane = _handler(offset_type=SPIN_PLANE)
         optimised = _handler(offset_type=SPIN_OPTIMISED)
-        assert plane.get_filename() == optimised.get_filename()
+        assert plane.get_filename() != optimised.get_filename()
+        assert "optimised" in optimised.get_filename()
+        assert "optimised" not in plane.get_filename()
         assert plane.get_folder_structure() != optimised.get_folder_structure()
 
     def test_supports_sequencing_and_bumps_version(self):
@@ -77,7 +87,7 @@ class TestCalculatedOffsetsPathHandler:
             pattern.search("imap_mag_mago-spin-plane-offsets_20260115_v024.csv") is None
         )
 
-    def test_from_filename_roundtrip(self):
+    def test_from_filename_roundtrip_spin_plane(self):
         handler = CalculatedOffsetsPathHandler.from_filename(
             "imap_mag_magi-spin-plane-offsets_20260114_v007.csv"
         )
@@ -85,8 +95,17 @@ class TestCalculatedOffsetsPathHandler:
         assert handler.sensor == "magi"
         assert handler.content_date == DATE
         assert handler.version == 7
-        # offset_type is unknowable from the name alone.
-        assert handler.offset_type is None
+        # The descriptor identifies the offset type.
+        assert handler.offset_type == SPIN_PLANE
+
+    def test_from_filename_roundtrip_spin_optimised(self):
+        handler = CalculatedOffsetsPathHandler.from_filename(
+            "imap_mag_mago-spin-plane-optimised-offsets_20260114_v007.csv"
+        )
+        assert handler is not None
+        assert handler.sensor == "mago"
+        assert handler.offset_type == SPIN_OPTIMISED
+        assert handler.version == 7
 
     def test_from_filename_rejects_unrelated_names(self):
         assert CalculatedOffsetsPathHandler.from_filename("something_else.csv") is None
@@ -97,11 +116,11 @@ class TestCalculatedOffsetsPathHandler:
             is None
         )
 
-    def test_from_work_folder_file_infers_offset_type_from_parent(self, tmp_path):
+    def test_from_work_folder_file_optimised(self, tmp_path):
         f = (
             tmp_path
             / SPIN_OPTIMISED
-            / "imap_mag_mago-spin-plane-offsets_20260114_v000.csv"
+            / "imap_mag_mago-spin-plane-optimised-offsets_20260114_v000.csv"
         )
         f.parent.mkdir(parents=True)
         f.write_text("data")
@@ -113,6 +132,18 @@ class TestCalculatedOffsetsPathHandler:
         assert handler.get_folder_structure() == (
             "calibration/calculated_offsets/spin_optimised"
         )
+
+    def test_from_work_folder_file_rejects_folder_name_mismatch(self, tmp_path):
+        # A spin_plane-named file sitting in the spin_optimised folder is rejected.
+        f = (
+            tmp_path
+            / SPIN_OPTIMISED
+            / "imap_mag_mago-spin-plane-offsets_20260114_v000.csv"
+        )
+        f.parent.mkdir(parents=True)
+        f.write_text("data")
+        with pytest.raises(ValueError, match="implies offset type"):
+            CalculatedOffsetsPathHandler.from_work_folder_file(f)
 
     def test_from_work_folder_file_rejects_bad_folder(self, tmp_path):
         f = tmp_path / "wrong" / "imap_mag_mago-spin-plane-offsets_20260114_v000.csv"

--- a/tests/unit/test_scripted_l2_calibration.py
+++ b/tests/unit/test_scripted_l2_calibration.py
@@ -24,6 +24,7 @@ from mag_toolkit.calibration.CalibrationConfig import (
     ScriptedL2CalibrationConfig,
 )
 from mag_toolkit.calibration.calibrators.ScriptedL2Calibration import (
+    OFFSETS_FOLDER_NAME,
     SPARSE_DATASTORE_FOLDER_NAME,
     USER_CONFIG_FILENAME,
     ScriptedL2CalibrationJob,
@@ -90,6 +91,27 @@ def _handler(version: int) -> CalibrationLayerPathHandler:
     return CalibrationLayerPathHandler(
         descriptor="manual-norm", content_date=DATE, version=version
     )
+
+
+def _write_work_offsets(
+    work_folder: Path, date: datetime = DATE, tag: str = "a"
+) -> None:
+    """Simulate MATLAB writing the four spin-plane offset CSVs into the work folder.
+
+    One CSV per sensor (mago/magi) per offset type (spin_plane/spin_optimised);
+    content is tagged so tests can force identical vs changed content.
+    """
+    from imap_mag.io.file.CalculatedOffsetsPathHandler import OFFSET_TYPES
+
+    for offset_type in OFFSET_TYPES:
+        folder = work_folder / OFFSETS_FOLDER_NAME / offset_type
+        folder.mkdir(parents=True, exist_ok=True)
+        for sensor in ("mago", "magi"):
+            name = (
+                f"imap_mag_{sensor}-spin-plane-offsets_"
+                f"{date.strftime('%Y%m%d')}_v000.csv"
+            )
+            (folder / name).write_text(f"offsets,{sensor},{offset_type},{tag}\n")
 
 
 def test_requires_matlab_repo_path(tmp_path):
@@ -448,3 +470,151 @@ def test_scripted_calibrate_cli_publishes_layer(
         temp_datastore
         / "calibration/layers/2026/01/imap_mag_manual-norm-layer-data_20260130_v001.0001.csv"
     ).exists()
+
+
+def test_write_offsets_threads_flag_config_and_collects_files(tmp_path, monkeypatch):
+    """With write_offsets set: MATLAB gets the flag + folder, and CSVs are collected."""
+    job = _make_job(tmp_path)
+    work_folder = job.work_folder
+    config = ScriptedL2CalibrationConfig(
+        calibration_matrix_version=8,
+        input_json_file="input.json",
+        matlab_repo=str(job.matlab_repo_path),
+        write_offsets=True,
+    )
+
+    captured = {}
+
+    def mock_call_matlab(command, **kwargs):
+        captured["command"] = command
+        captured["config"] = json.loads(
+            (work_folder / USER_CONFIG_FILENAME).read_text()
+        )
+        # The offsets sub-folders must already exist for MATLAB to write into.
+        assert (work_folder / OFFSETS_FOLDER_NAME / "spin_plane").is_dir()
+        assert (work_folder / OFFSETS_FOLDER_NAME / "spin_optimised").is_dir()
+        write_calibration_layer_pair(work_folder, "manual-norm", DATE, 1)
+        _write_work_offsets(work_folder)
+
+    monkeypatch.setattr(MODULE_CALL_MATLAB, mock_call_matlab)
+    job.run_calibration(_handler(1), config)
+
+    assert "write_offsets=true" in captured["command"]
+    assert captured["config"]["output_offsets_folder"] == str(
+        (work_folder / OFFSETS_FOLDER_NAME).resolve()
+    )
+    # Four offsets collected: mago/magi x spin_plane/spin_optimised.
+    assert len(job.written_offset_files) == 4
+    assert {f.parent.name for f in job.written_offset_files} == {
+        "spin_plane",
+        "spin_optimised",
+    }
+
+
+def test_write_offsets_defaults_off(tmp_path, monkeypatch):
+    """Without the flag, MATLAB is told write_offsets=false and nothing is collected."""
+    job = _make_job(tmp_path)
+    work_folder = job.work_folder
+    config = ScriptedL2CalibrationConfig(
+        calibration_matrix_version=8,
+        input_json_file="input.json",
+        matlab_repo=str(job.matlab_repo_path),
+    )
+
+    captured = {}
+
+    def mock_call_matlab(command, **kwargs):
+        captured["command"] = command
+        write_calibration_layer_pair(work_folder, "manual-norm", DATE, 1)
+
+    monkeypatch.setattr(MODULE_CALL_MATLAB, mock_call_matlab)
+    job.run_calibration(_handler(1), config)
+
+    assert "write_offsets=false" in captured["command"]
+    assert job.written_offset_files == []
+
+
+def _run_scripted_cli_with_offsets(monkeypatch, work_folder: Path, tag: str) -> None:
+    """Run the calibrate() CLI for the scripted-L2 method with offsets enabled."""
+
+    def mock_call_matlab(command, **kwargs):
+        write_calibration_layer_pair(work_folder, "manual-norm", DATE, 1)
+        _write_work_offsets(work_folder, tag=tag)
+
+    monkeypatch.setattr(MODULE_CALL_MATLAB, mock_call_matlab)
+
+    repo = _make_matlab_repo(work_folder.parent / f"repo_{tag}")
+    config = ScriptedL2CalibrationConfig(
+        calibration_matrix_version=8,
+        input_json_file="+calibration/calibration/input_v002.json",
+        matlab_repo=str(repo),
+        write_offsets=True,
+    )
+    calibrate(
+        start_date=DATE,
+        method=CalibrationMethod.SCRIPTED_L2_CALIBRATION,
+        mode=ScienceMode.Normal,
+        configuration=config.model_dump_json(),
+        metakernel=Path("metakernel.txt"),
+    )
+
+
+def _offsets_path(datastore: Path, offset_type: str, sensor: str, version: int) -> Path:
+    return (
+        datastore
+        / "calibration/calculated_offsets"
+        / offset_type
+        / f"imap_mag_{sensor}-spin-plane-offsets_20260130_v{version:03d}.csv"
+    )
+
+
+def test_scripted_calibrate_cli_publishes_offsets(
+    monkeypatch, temp_datastore, dynamic_work_folder, tmp_path
+):
+    """First run publishes the four offset CSVs at v001 in the datastore."""
+    work_folder = dynamic_work_folder / "calibrate_20260130_norm"
+    _run_scripted_cli_with_offsets(monkeypatch, work_folder, tag="a")
+
+    for offset_type in ("spin_plane", "spin_optimised"):
+        for sensor in ("mago", "magi"):
+            assert _offsets_path(temp_datastore, offset_type, sensor, 1).exists()
+
+
+def test_scripted_calibrate_cli_upversions_changed_offsets(
+    monkeypatch, temp_datastore, dynamic_work_folder, tmp_path
+):
+    """Different content vs the latest datastore offsets is written as a new version."""
+    # Seed the datastore with a v001 that differs from what the run will produce.
+    for offset_type in ("spin_plane", "spin_optimised"):
+        for sensor in ("mago", "magi"):
+            existing = _offsets_path(temp_datastore, offset_type, sensor, 1)
+            existing.parent.mkdir(parents=True, exist_ok=True)
+            existing.write_text("pre-existing different content\n")
+
+    work_folder = dynamic_work_folder / "calibrate_20260130_norm"
+    _run_scripted_cli_with_offsets(monkeypatch, work_folder, tag="new")
+
+    for offset_type in ("spin_plane", "spin_optimised"):
+        for sensor in ("mago", "magi"):
+            assert _offsets_path(temp_datastore, offset_type, sensor, 1).exists()
+            assert _offsets_path(temp_datastore, offset_type, sensor, 2).exists()
+
+
+def test_scripted_calibrate_cli_reuses_identical_offsets(
+    monkeypatch, temp_datastore, dynamic_work_folder, tmp_path
+):
+    """Identical content to the latest datastore offsets does not create a new version."""
+    # Seed the datastore v001 with byte-identical content to what the run produces.
+    for offset_type in ("spin_plane", "spin_optimised"):
+        for sensor in ("mago", "magi"):
+            existing = _offsets_path(temp_datastore, offset_type, sensor, 1)
+            existing.parent.mkdir(parents=True, exist_ok=True)
+            existing.write_text(f"offsets,{sensor},{offset_type},same\n")
+
+    work_folder = dynamic_work_folder / "calibrate_20260130_norm"
+    _run_scripted_cli_with_offsets(monkeypatch, work_folder, tag="same")
+
+    for offset_type in ("spin_plane", "spin_optimised"):
+        for sensor in ("mago", "magi"):
+            assert _offsets_path(temp_datastore, offset_type, sensor, 1).exists()
+            assert not _offsets_path(temp_datastore, offset_type, sensor, 2).exists()

--- a/tests/unit/test_scripted_l2_calibration.py
+++ b/tests/unit/test_scripted_l2_calibration.py
@@ -99,19 +99,22 @@ def _write_work_offsets(
     """Simulate MATLAB writing the four spin-plane offset CSVs into the work folder.
 
     One CSV per sensor (mago/magi) per offset type (spin_plane/spin_optimised);
-    content is tagged so tests can force identical vs changed content.
+    the per-type file name is derived from the path handler so it matches production.
+    Content is tagged so tests can force identical vs changed content.
     """
+    from imap_mag.io.file import CalculatedOffsetsPathHandler
     from imap_mag.io.file.CalculatedOffsetsPathHandler import OFFSET_TYPES
 
     for offset_type in OFFSET_TYPES:
         folder = work_folder / OFFSETS_FOLDER_NAME / offset_type
         folder.mkdir(parents=True, exist_ok=True)
         for sensor in ("mago", "magi"):
-            name = (
-                f"imap_mag_{sensor}-spin-plane-offsets_"
-                f"{date.strftime('%Y%m%d')}_v000.csv"
+            handler = CalculatedOffsetsPathHandler(
+                sensor=sensor, offset_type=offset_type, content_date=date, version=0
             )
-            (folder / name).write_text(f"offsets,{sensor},{offset_type},{tag}\n")
+            (folder / handler.get_filename()).write_text(
+                f"offsets,{sensor},{offset_type},{tag}\n"
+            )
 
 
 def test_requires_matlab_repo_path(tmp_path):
@@ -560,12 +563,12 @@ def _run_scripted_cli_with_offsets(monkeypatch, work_folder: Path, tag: str) -> 
 
 
 def _offsets_path(datastore: Path, offset_type: str, sensor: str, version: int) -> Path:
-    return (
-        datastore
-        / "calibration/calculated_offsets"
-        / offset_type
-        / f"imap_mag_{sensor}-spin-plane-offsets_20260130_v{version:03d}.csv"
+    from imap_mag.io.file import CalculatedOffsetsPathHandler
+
+    handler = CalculatedOffsetsPathHandler(
+        sensor=sensor, offset_type=offset_type, content_date=DATE, version=version
     )
+    return handler.get_full_path(datastore)
 
 
 def test_scripted_calibrate_cli_publishes_offsets(
@@ -578,6 +581,16 @@ def test_scripted_calibrate_cli_publishes_offsets(
     for offset_type in ("spin_plane", "spin_optimised"):
         for sensor in ("mago", "magi"):
             assert _offsets_path(temp_datastore, offset_type, sensor, 1).exists()
+
+    # Pin the exact (unique) file names for each product.
+    base = temp_datastore / "calibration/calculated_offsets"
+    assert (
+        base / "spin_plane/imap_mag_mago-spin-plane-offsets_20260130_v001.csv"
+    ).exists()
+    assert (
+        base
+        / "spin_optimised/imap_mag_mago-spin-plane-optimised-offsets_20260130_v001.csv"
+    ).exists()
 
 
 def test_scripted_calibrate_cli_upversions_changed_offsets(


### PR DESCRIPTION
Integrate the scripted-L2 MATLAB calibration's optional offsets output with the datastore.

- Add a `write_offsets` option to ScriptedL2CalibrationConfig so it can be toggled from the Prefect UI. When set, MATLAB is told to write the calculated spin-plane offsets into an `offsets/` folder in the run's work folder.
- Add CalculatedOffsetsPathHandler mapping to calibration/calculated_offsets/{spin_plane,spin_optimised}. The two products share a file name and are distinguished by their folder.
- After calibration, publish each collected offsets CSV via the datastore file manager, which compares content by hash against the latest datastore version and upversions (and indexes in the database) only when it differs.

Tests cover the new path handler, the flag/config/user-config threading and CSV collection, the CLI end-to-end publish/upversion/reuse behaviour, and database indexing of the offsets files.

This also exposed an architecture issue where the base spin plane offsets and the optimised offsets files had the same name, so I have made small accompanying changes in the cal code - https://github.com/ImperialCollegeLondon/IMAP_MAG_Calibration/pull/78/changes - so that the offsets file names are unique.