### PR TITLE
fix: use xvfb-run to provide virtual display for headless MATLAB plotting

### DIFF
--- a/deploy/MATLAB-Dockerfile
+++ b/deploy/MATLAB-Dockerfile
@@ -105,6 +105,7 @@ RUN apt-get update && apt-get install -y \
     libcups2t64 \
     libncurses6 \
     libasound2t64 \
+    xvfb \
     git \
     wget \
     && apt-get clean && \

--- a/src/mag_toolkit/calibration/MatlabWrapper.py
+++ b/src/mag_toolkit/calibration/MatlabWrapper.py
@@ -79,6 +79,21 @@ def get_matlab_command():
         return "matlab"
 
 
+def _get_display_wrapper() -> list[str]:
+    """Return an xvfb-run prefix if available, otherwise an empty list.
+
+    MATLAB's graphics subsystem needs some X11 infrastructure even in batch
+    mode when generating figures for report files.  ``xvfb-run`` spins up an
+    ephemeral virtual framebuffer for each invocation so MATLAB can render
+    off-screen without a physical display.  When ``xvfb-run`` is absent (e.g.
+    on a developer machine) the prefix is omitted and the caller falls back to
+    the previous behaviour of running MATLAB directly.
+    """
+    if os.name == "posix" and which("xvfb-run") is not None:
+        return ["xvfb-run", "--auto-servernum"]
+    return []
+
+
 def call_matlab(
     command,
     timeout=60 * 5,
@@ -94,8 +109,10 @@ def call_matlab(
     (it is persisted via ``savepath``), and self-contained external MATLAB projects
     pass ``include_project_paths=False`` to opt out entirely.
 
-    ``DISPLAY`` is always removed from the environment so MATLAB never tries to
-    open plot windows.
+    ``DISPLAY`` is always removed from the environment passed to the subprocess.
+    When ``xvfb-run`` is available it wraps the MATLAB command and sets its own
+    isolated ``DISPLAY`` for the child process, allowing MATLAB to render figures
+    off-screen without a physical display.
 
     Args:
         command: The MATLAB command to run inside ``matlab -batch``.
@@ -120,9 +137,18 @@ def call_matlab(
     else:
         batch_command = command
 
-    cmd = [MATLAB_COMMAND, "-nodesktop", "-nojvm", "-batch", batch_command]
+    display_wrapper = _get_display_wrapper()
+    cmd = [
+        *display_wrapper,
+        MATLAB_COMMAND,
+        "-nodesktop",
+        "-nojvm",
+        "-batch",
+        batch_command,
+    ]
 
-    # Always unset DISPLAY so MATLAB does not attempt to open plot windows.
+    # Remove DISPLAY so the host display never leaks into the subprocess.
+    # xvfb-run (when present) sets its own isolated DISPLAY for MATLAB.
     env = os.environ.copy()
     env.pop("DISPLAY", None)
 

--- a/tests/unit/test_matlab_wrapper.py
+++ b/tests/unit/test_matlab_wrapper.py
@@ -9,6 +9,7 @@ import pytest
 
 import mag_toolkit.calibration.MatlabWrapper as matlab_wrapper
 from mag_toolkit.calibration.MatlabWrapper import (
+    _get_display_wrapper,
     call_matlab,
     get_matlab_command,
 )
@@ -82,6 +83,32 @@ class TestSetupMatlabPathPrefix:
         assert "src/matlab" in prefix
         assert "addpath" in prefix
         assert "savepath" in prefix
+
+
+class TestGetDisplayWrapper:
+    def test_returns_xvfb_run_on_posix_when_available(self):
+        with (
+            patch("mag_toolkit.calibration.MatlabWrapper.os.name", "posix"),
+            patch(
+                "mag_toolkit.calibration.MatlabWrapper.which",
+                return_value="/usr/bin/xvfb-run",
+            ),
+        ):
+            result = _get_display_wrapper()
+        assert result == ["xvfb-run", "--auto-servernum"]
+
+    def test_returns_empty_on_posix_when_xvfb_not_found(self):
+        with (
+            patch("mag_toolkit.calibration.MatlabWrapper.os.name", "posix"),
+            patch("mag_toolkit.calibration.MatlabWrapper.which", return_value=None),
+        ):
+            result = _get_display_wrapper()
+        assert result == []
+
+    def test_returns_empty_on_non_posix(self):
+        with patch("mag_toolkit.calibration.MatlabWrapper.os.name", "nt"):
+            result = _get_display_wrapper()
+        assert result == []
 
 
 class TestCallMatlab:
@@ -191,7 +218,7 @@ class TestCallMatlabExternalRepo:
         assert kwargs["cwd"] == str(tmp_path)
 
     def test_always_unsets_display(self):
-        """DISPLAY is removed from the MATLAB environment on every call."""
+        """DISPLAY is removed from the environment passed to the subprocess."""
         mock_process = _make_mock_process(returncode=0)
 
         with (
@@ -209,6 +236,54 @@ class TestCallMatlabExternalRepo:
 
         kwargs = mock_popen.call_args.kwargs
         assert "DISPLAY" not in kwargs["env"]
+
+    def test_command_prefixed_with_xvfb_run_when_available(self):
+        """xvfb-run --auto-servernum is prepended to the MATLAB command when present."""
+        mock_process = _make_mock_process(returncode=0)
+
+        with (
+            patch(
+                "mag_toolkit.calibration.MatlabWrapper.subprocess.Popen",
+                return_value=mock_process,
+            ) as mock_popen,
+            patch(
+                "mag_toolkit.calibration.MatlabWrapper.get_matlab_command",
+                return_value="matlab",
+            ),
+            patch(
+                "mag_toolkit.calibration.MatlabWrapper._get_display_wrapper",
+                return_value=["xvfb-run", "--auto-servernum"],
+            ),
+        ):
+            call_matlab("run()", include_project_paths=False)
+
+        cmd = mock_popen.call_args[0][0]
+        assert cmd[0] == "xvfb-run"
+        assert cmd[1] == "--auto-servernum"
+        assert cmd[2] == "matlab"
+
+    def test_command_not_prefixed_when_xvfb_unavailable(self):
+        """No xvfb-run prefix when _get_display_wrapper returns empty."""
+        mock_process = _make_mock_process(returncode=0)
+
+        with (
+            patch(
+                "mag_toolkit.calibration.MatlabWrapper.subprocess.Popen",
+                return_value=mock_process,
+            ) as mock_popen,
+            patch(
+                "mag_toolkit.calibration.MatlabWrapper.get_matlab_command",
+                return_value="matlab",
+            ),
+            patch(
+                "mag_toolkit.calibration.MatlabWrapper._get_display_wrapper",
+                return_value=[],
+            ),
+        ):
+            call_matlab("run()", include_project_paths=False)
+
+        cmd = mock_popen.call_args[0][0]
+        assert cmd[0] == "matlab"
 
     def test_default_call_has_no_cwd(self):
         mock_process = _make_mock_process(returncode=0)


### PR DESCRIPTION
## Problem

When the L2 scripted calibration flow runs MATLAB in the Docker container, MATLAB crashes while writing a report file that contains plots. The root cause is that MATLAB's graphics subsystem attempts to initialise X11 display infrastructure even in `-batch` mode when rendering figures — and the container has no display server.

Previously the code worked around this by unsetting `DISPLAY` before spawning MATLAB, but that only prevents MATLAB from trying to connect to an *existing* display; it does not suppress the underlying graphics initialisation that fails when no display is available at all.

## Fix

Two changes:

**`deploy/MATLAB-Dockerfile`** — add `xvfb` (X Virtual Framebuffer) to the apt packages installed in the runtime image. This provides the `xvfb-run` helper without requiring a desktop environment.

**`src/mag_toolkit/calibration/MatlabWrapper.py`** — introduce `_get_display_wrapper()`, which returns `["xvfb-run", "--auto-servernum"]` when `xvfb-run` is on the PATH (Linux only), or an empty list otherwise. The MATLAB invocation is prefixed with this wrapper so each call gets its own ephemeral virtual framebuffer. `xvfb-run` sets its own isolated `DISPLAY` for the MATLAB child process, so MATLAB can create and save figures off-screen.

The graceful fallback (empty wrapper) means developer machines without `xvfb` installed continue to work as before — the wrapper is purely additive in the Docker environment.

`DISPLAY` is still removed from the environment dictionary passed to `subprocess.Popen`, so the host display can never leak through.

Docs: https://uk.mathworks.com/help/slcheck/padv/ug/tips-for-setting-up-ci-agents.html