### PR TITLE
feat: calibration multi-file output + version-number override (v6.3.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,4 @@ tests/datastore/spice/spk/de440.bsp
 tests/datastore/ialirt/
 .claude/settings.local.json
 tests/datastore/hk/mag/l0/hsk-pw/2025/05/
+tests/datastore/calibration/reports/*.html

--- a/imap-mag-config.yaml
+++ b/imap-mag-config.yaml
@@ -117,7 +117,7 @@ calibrate:
             - pattern: 'calibration/calculated_offsets/kepko/*'
             - pattern: 'calibration/calculated_offsets/leinweber/*'
             - pattern: 'calibration/calculated_offsets/spin_axis/*'
-            - pattern: 'calibration/calculated_offsets/spin_optimised/imap_mag_*-spin-plane-offsets_%Y%m%d_v{sequence}.csv*'
+            - pattern: 'calibration/calculated_offsets/spin_optimised/imap_mag_*-spin-plane-optimised-offsets_%Y%m%d_v{sequence}.csv*'
               days_before: 1
               days_after: 1
               get_previous_if_empty: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 requires-python = ">=3.11,<3.13" # blocked by imap_processing https://github.com/IMAP-Science-Operations-Center/imap_processing/blob/dev/pyproject.toml#L17
 name = "imap-mag"
-version = "6.2.0"
+version = "6.3.0"
 description = "Process IMAP data"
 authors = [
   {name = "alastairtree"},

--- a/src/imap_mag/cli/apply.py
+++ b/src/imap_mag/cli/apply.py
@@ -312,7 +312,11 @@ def _apply_for_date(
         logger.info(
             "No calibration layers provided, proceeding with apply using only rotation. A temporary zero offset layer will be created."
         )
-        workLayers = [_setup_zero_calibration_layer(work_folder, workScienceFile, date)]
+        workLayers = [
+            _setup_zero_calibration_layer(
+                work_folder, workScienceFile, date, app_settings
+            )
+        ]
 
     (L2_files, offset_file) = applier.apply(
         day_to_process=date,
@@ -387,15 +391,19 @@ def cleanup_workfolder_after_apply(
 
 
 def _setup_zero_calibration_layer(
-    work_folder: Path, workScienceFile: Path, content_date: datetime
+    work_folder: Path,
+    workScienceFile: Path,
+    content_date: datetime,
+    app_settings: AppSettings,
 ) -> Path:
     logger.info(
         "No calibration layers provided, setting up a zero calibration layer for application."
     )
 
-    calibration_handler = CalibrationLayerPathHandler(
-        descriptor=CalibrationMethod.NOOP.short_name, content_date=content_date
+    calibration_handler = CalibrationLayerPathHandler.from_method(
+        method=CalibrationMethod.NOOP, content_date=content_date, settings=app_settings
     )
+
     new_layer_file = work_folder / calibration_handler.get_filename()
     if new_layer_file.exists():
         logger.warning(
@@ -405,7 +413,7 @@ def _setup_zero_calibration_layer(
 
     science_layer = ScienceLayer.from_file(workScienceFile, load_contents=True)
     zero_offset_layer = CalibrationLayer.create_zero_offset_layer_from_science(
-        science_layer
+        science_layer, app_settings
     )
     del science_layer
 

--- a/src/imap_mag/cli/calibrate.py
+++ b/src/imap_mag/cli/calibrate.py
@@ -16,6 +16,10 @@ from imap_mag.config import (
 from imap_mag.db.Database import Database
 from imap_mag.io import DatastoreFileManager, FileFinder
 from imap_mag.io.file import CalibrationLayerPathHandler
+from imap_mag.io.file.VersionedPathHandler import VersionedPathHandler
+from imap_mag.io.FilePathHandlerSelector import (
+    FilePathHandlerSelector,
+)
 from imap_mag.util import ScienceMode
 from mag_toolkit.calibration import (
     CalibrationJob,
@@ -35,6 +39,45 @@ logger = logging.getLogger(__name__)
 app.command()(apply.apply)
 
 
+def _validate_version_number_override(
+    override: tuple[int, int] | None,
+) -> tuple[int, int] | None:
+    """Validate a (major, minor) version override tuple.
+
+    Each element must be a non-negative whole integer with major <= 999 and
+    minor <= 9999, mirroring the range checks MATLAB applies to output_version.
+
+    Args:
+        override: A (major, minor) pair, or None to use default versioning.
+
+    Returns:
+        The validated pair, or None.
+
+    Raises:
+        ValueError: If any element is a bool, non-integer, negative, or out of range.
+    """
+    if override is None:
+        return None
+
+    major, minor = override
+    for val, name, max_val in [
+        (major, "major", 999),
+        (minor, "minor", 9999),
+    ]:
+        if isinstance(val, bool):
+            raise ValueError(f"Version {name} must be an integer, not bool.")
+        if not isinstance(val, int):
+            raise ValueError(
+                f"Version {name} must be an integer, got {type(val).__name__}."
+            )
+        if val < 0:
+            raise ValueError(f"Version {name} must be non-negative, got {val}.")
+        if val > max_val:
+            raise ValueError(f"Version {name} must be at most {max_val}, got {val}.")
+
+    return (major, minor)
+
+
 def gradiometry(
     start_date: Annotated[datetime, typer.Option("--date", help="Date to calibrate")],
     mode: Annotated[
@@ -48,7 +91,7 @@ def gradiometry(
         SaveMode,
         typer.Option(help="Whether to save locally only or to also save to database"),
     ] = SaveMode.LocalOnly,
-) -> Path:
+) -> list[Path]:
     """
     Run gradiometry calibration.
     """
@@ -115,6 +158,15 @@ def calibrate(
             "If False, temporary files are retained in the work folder for inspection.",
         ),
     ] = True,
+    version_number_override: Annotated[
+        tuple[int, int] | None,
+        typer.Option(
+            "--version-number-override",
+            help="Force a specific (major, minor) version number for output layers "
+            "instead of auto-incrementing. Existing layers at that version are "
+            "overwritten. Provide as two integers, e.g. --version-number-override 1 5.",
+        ),
+    ] = None,
 ) -> list[Path]:
     """
     Generate calibration parameters for a given input file.
@@ -140,8 +192,9 @@ def calibrate(
             save_mode=save_mode,
             metakernel=metakernel,
             cleanup_temp_files_after_run=cleanup_temp_files_after_run,
+            version_number_override=version_number_override,
         )
-        results.append(result)
+        results.extend(result)
         current += timedelta(days=1)
     return results
 
@@ -155,7 +208,8 @@ def _calibrate_for_date(
     save_mode: SaveMode,
     metakernel: Path | None = None,
     cleanup_temp_files_after_run: bool = True,
-) -> Path:
+    version_number_override: tuple[int, int] | None = None,
+) -> list[Path]:
     """Run calibration for a single date."""
     if method == CalibrationMethod.NOOP:
         # NOOP is retained only as the internal descriptor for the zero-offset layer
@@ -164,6 +218,9 @@ def _calibrate_for_date(
             "The 'noop' calibration method is not runnable. It exists only for the "
             "internal zero-offset layer. Choose a real calibration method."
         )
+
+    version_number_override = _validate_version_number_override(version_number_override)
+
     app_settings = AppSettings()  # type: ignore
     # Use the dedicated calibrate command config so each run gets its own uniquely
     # named work folder (based on the date + mode being calibrated).
@@ -239,45 +296,121 @@ def _calibrate_for_date(
     outputManager = DatastoreFileManager.CreateByMode(
         settings_for_output, use_database=save_mode == SaveMode.LocalAndDatabase
     )
-    calibration_handler = CalibrationLayerPathHandler(
-        descriptor=f"{method.short_name}-{mode.value}",
-        content_date=start_date,
-        version_major=app_settings.version_major,
-    )
+
+    if version_number_override is not None:
+        major, minor = version_number_override
+        logger.warning(
+            f"Version number override active: forcing output to v{major:03d}.{minor:04d}. "
+            "Existing layers at this version may be overwritten."
+        )
+        calibration_handler = CalibrationLayerPathHandler(
+            descriptor=f"{method.short_name}-{mode.value}",
+            content_date=start_date,
+            version_major=major,
+            version=minor,
+            has_major_version=True,
+        )
+        calibration_handler.allow_overwrite = True
+    else:
+        calibration_handler = CalibrationLayerPathHandler(
+            descriptor=f"{method.short_name}-{mode.value}",
+            content_date=start_date,
+            version_major=app_settings.version_major,
+        )
 
     try:
-        metadata_path, data_path = calibrator.run_calibration(
-            calibration_handler, calibration_configuration
+        returned = list(
+            calibrator.run_calibration(calibration_handler, calibration_configuration)
         )
     finally:
         calibrator.cleanup()
 
-    # verify that the generated work-folder pair is internally consistent
-    layer = CalibrationLayer.from_file(metadata_path, load_contents=False)
-    if not layer.metadata.data_filename or not data_path.exists():
-        raise FileNotFoundError(
-            f"Calibration layer file at {metadata_path!s} has data file {layer.metadata.data_filename!s} that was not found"
+    if not returned:
+        raise ValueError("Calibration produced no files to save.")
+
+    # Resolve a path handler for every returned file. The selector raises
+    # NoProviderFoundError for any file it cannot recognise, so an unhandled
+    # file type surfaces immediately rather than being silently dropped.
+    file_handlers: dict[Path, object] = {}
+    for path in returned:
+        handler = FilePathHandlerSelector.find_by_path(path)
+        if version_number_override is not None and isinstance(
+            handler, VersionedPathHandler
+        ):
+            handler.allow_overwrite = True
+        file_handlers[path] = handler
+
+    consumed: set[Path] = set()
+    saved_layer_paths: list[Path] = []
+
+    # Process JSON calibration-layer files first so co-versioning is preserved:
+    # adding the JSON bumps its handler's version, and the CSV is then saved with
+    # the bumped handler — both land on the same version number.
+    for path in returned:
+        handler = file_handlers[path]
+        if not isinstance(handler, CalibrationLayerPathHandler):
+            continue
+        if handler.extension != "json":
+            continue
+
+        layer = CalibrationLayer.from_file(path, load_contents=False)
+        if not layer.metadata.data_filename:
+            raise FileNotFoundError(
+                f"Calibration layer file at {path!s} has no data_filename in its metadata."
+            )
+
+        companion_path = next(
+            (p for p in returned if p.name == layer.metadata.data_filename.name),
+            None,
         )
-    if data_path.name != layer.metadata.data_filename.name:
-        raise ValueError(
-            f"Calibration layer metadata file {metadata_path!s} specifies data file {layer.metadata.data_filename!s} but actual data file is {data_path!s}."
+        if companion_path is None or not companion_path.exists():
+            raise FileNotFoundError(
+                f"Calibration layer file at {path!s} has data file "
+                f"{layer.metadata.data_filename!s} that was not found among the "
+                "calibration outputs."
+            )
+        if companion_path.name != layer.metadata.data_filename.name:
+            raise ValueError(
+                f"Calibration layer metadata file {path!s} specifies data file "
+                f"{layer.metadata.data_filename!s} but matched data file is "
+                f"{companion_path!s}."
+            )
+
+        # Enforce pipeline metadata (ensures hash is correct).
+        layer.save_calibration_layer(path, createDirectory=False, save_contents=False)
+
+        (saved_json, _) = outputManager.add_file(path, path_handler=handler)
+        saved_layer_paths.append(saved_json)
+        consumed.add(path)
+
+        # Save the companion CSV using the handler derived from the JSON handler
+        # after add_file may have bumped its version — preserving co-versioning.
+        outputManager.add_file(
+            companion_path,
+            path_handler=handler.get_equivalent_data_handler(),
         )
+        consumed.add(companion_path)
 
-    # Enforce pipeline metadata, ensures hash is correct as MATLAB cal may not do it
-    layer.save_calibration_layer(
-        metadata_path, createDirectory=False, save_contents=False
-    )
-
-    (output_calibration_path, _) = outputManager.add_file(
-        metadata_path, path_handler=calibration_handler
-    )
-
-    outputManager.add_file(
-        data_path, path_handler=calibration_handler.get_equivalent_data_handler()
-    )
+    # Save any remaining files (extra products beyond the layer pair).
+    for path in returned:
+        if path in consumed:
+            continue
+        handler = file_handlers[path]
+        # Re-save if this is an additional JSON layer (keeps metadata consistent).
+        if (
+            isinstance(handler, CalibrationLayerPathHandler)
+            and handler.extension == "json"
+        ):
+            extra_layer = CalibrationLayer.from_file(path, load_contents=False)
+            extra_layer.save_calibration_layer(
+                path, createDirectory=False, save_contents=False
+            )
+        outputManager.add_file(path, path_handler=handler)
+        consumed.add(path)
 
     logger.info(
-        f"Calibration complete for {start_date.strftime('%Y-%m-%d')} ({mode.value}) written to {output_calibration_path!s}."
+        f"Calibration complete for {start_date.strftime('%Y-%m-%d')} ({mode.value}): "
+        f"{len(saved_layer_paths)} layer(s) written to datastore."
     )
 
-    return output_calibration_path
+    return saved_layer_paths

--- a/src/imap_mag/cli/calibrate.py
+++ b/src/imap_mag/cli/calibrate.py
@@ -23,15 +23,17 @@ from imap_mag.io.FilePathHandlerSelector import (
 )
 from imap_mag.util import ScienceMode
 from mag_toolkit.calibration import (
-    CalibrationJob,
     CalibrationJobParameters,
     CalibrationMethod,
-    GradiometerCalibrationJob,
-    ScriptedL2CalibrationJob,
     Sensor,
-    SetQualityAndNaNCalibrationJob,
 )
 from mag_toolkit.calibration.CalibrationLayer import CalibrationLayer
+from mag_toolkit.calibration.calibrators import (
+    CalibrationJob,
+    GradiometerCalibrationJob,
+    ScriptedL2CalibrationJob,
+    SetQualityAndNaNCalibrationJob,
+)
 
 app = typer.Typer()
 

--- a/src/imap_mag/cli/calibrate.py
+++ b/src/imap_mag/cli/calibrate.py
@@ -14,8 +14,9 @@ from imap_mag.config import (
     SaveMode,
 )
 from imap_mag.db.Database import Database
-from imap_mag.io import DatastoreFileManager, FileFinder
+from imap_mag.io import DatastoreFileManager, FileFinder, IDatastoreFileManager
 from imap_mag.io.file import CalibrationLayerPathHandler
+from imap_mag.io.file.IFilePathHandler import IFilePathHandler
 from imap_mag.io.file.VersionedPathHandler import VersionedPathHandler
 from imap_mag.io.FilePathHandlerSelector import (
     FilePathHandlerSelector,
@@ -75,7 +76,100 @@ def _validate_version_number_override(
         if val > max_val:
             raise ValueError(f"Version {name} must be at most {max_val}, got {val}.")
 
+    logger.warning(
+        f"Version number override active: forcing output to v{major:03d}.{minor:04d}. "
+        "Existing layers at this version may be overwritten."
+    )
+
     return (major, minor)
+
+
+def _save_calibration_outputs(
+    returned: list[Path],
+    outputManager: IDatastoreFileManager,
+    version_number_override: tuple[int, int] | None = None,
+) -> list[Path]:
+
+    if not returned:
+        raise ValueError("Calibration produced no files to save.")
+
+    # Tuple: (is_layer_metadata, original_output_path, handler) for all returned files.
+    file_handlers: list[tuple[bool, Path, IFilePathHandler]] = []
+    saved_file_paths: list[Path] = []
+
+    # Resolve a path handler for the returned files. The selector raises
+    # NoProviderFoundError for any file it cannot recognise, so an unhandled
+    # file type surfaces immediately rather than being silently dropped.
+    for path in returned:
+        handler: IFilePathHandler = FilePathHandlerSelector.find_by_path(path)
+        if version_number_override is not None and isinstance(
+            handler, VersionedPathHandler
+        ):
+            handler.versioning_mode = VersionedPathHandler.VersionMode.USER_OVERRIDE
+            if (handler.version_major, handler.version) != version_number_override:
+                raise ValueError(
+                    f"Version number override {version_number_override} does not match the version {handler.version_major, handler.version} for discovered output file {path}."
+                )
+
+        if isinstance(handler, CalibrationLayerPathHandler):
+            if not handler.is_metadata_file():
+                # Companion data file for a calibration layer; skip it for now and
+                # handle it when the JSON layer is processed.
+                continue
+
+            file_handlers.append((True, path, handler))
+        else:
+            file_handlers.append((False, path, handler))
+
+    # Process JSON calibration-layer files first so co-versioning is preserved:
+    # adding the JSON bumps its handler's version, and the CSV is then saved with
+    # the bumped handler — both land on the same version number.
+
+    for is_layer_metadata, path, handler in sorted(
+        file_handlers, key=lambda x: x[0], reverse=True
+    ):
+        companion_path: Path | None = None
+        if is_layer_metadata:
+            layer = CalibrationLayer.from_file(path, load_contents=False)
+            if not layer.metadata.data_filename:
+                raise FileNotFoundError(
+                    f"Calibration layer file at {path!s} has no data_filename in its metadata."
+                )
+
+            companion_path = next(
+                (p for p in returned if p.name == layer.metadata.data_filename.name),
+                None,
+            )
+            if companion_path is None or not companion_path.exists():
+                raise FileNotFoundError(
+                    f"Calibration layer file at {path!s} has data file "
+                    f"{layer.metadata.data_filename!s} that was not found among the "
+                    "calibration outputs."
+                )
+            if companion_path.name != layer.metadata.data_filename.name:
+                raise ValueError(
+                    f"Calibration layer metadata file {path!s} specifies data file "
+                    f"{layer.metadata.data_filename!s} but matched data file is "
+                    f"{companion_path!s}."
+                )
+
+            # Enforce pipeline metadata (ensures hash is correct).
+            layer.save_calibration_layer(
+                path, createDirectory=False, save_contents=False
+            )
+
+        destination, _ = outputManager.add_file(path, path_handler=handler)
+        saved_file_paths.append(destination)
+
+        if companion_path:
+            # Add the companion data file to the output manager with its equivalent data handler, ensuring both files are saved together and co-versioned.
+            # we deliberately did not save the data file with its own handler, as that would cause it to be versioned independently of the JSON layer.
+            outputManager.add_file(
+                companion_path,
+                path_handler=handler.get_equivalent_data_handler(),  # type: ignore
+            )
+
+    return saved_file_paths
 
 
 def gradiometry(
@@ -221,14 +315,14 @@ def _calibrate_for_date(
 
     version_number_override = _validate_version_number_override(version_number_override)
 
-    app_settings = AppSettings()  # type: ignore
+    app_settings = AppSettings()
     # Use the dedicated calibrate command config so each run gets its own uniquely
     # named work folder (based on the date + mode being calibrated).
     work_folder = app_settings.setup_work_folder_for_command(
         app_settings.calibrate,
         name_context={
             "date": start_date.strftime("%Y%m%d"),
-            "mode": mode.value,
+            "mode": mode.short_name,
             "sensor": sensor.value,
         },
     )
@@ -297,26 +391,13 @@ def _calibrate_for_date(
         settings_for_output, use_database=save_mode == SaveMode.LocalAndDatabase
     )
 
-    if version_number_override is not None:
-        major, minor = version_number_override
-        logger.warning(
-            f"Version number override active: forcing output to v{major:03d}.{minor:04d}. "
-            "Existing layers at this version may be overwritten."
-        )
-        calibration_handler = CalibrationLayerPathHandler(
-            descriptor=f"{method.short_name}-{mode.value}",
-            content_date=start_date,
-            version_major=major,
-            version=minor,
-            has_major_version=True,
-        )
-        calibration_handler.allow_overwrite = True
-    else:
-        calibration_handler = CalibrationLayerPathHandler(
-            descriptor=f"{method.short_name}-{mode.value}",
-            content_date=start_date,
-            version_major=app_settings.version_major,
-        )
+    calibration_handler = CalibrationLayerPathHandler.from_method(
+        method=method,
+        content_date=start_date,
+        mode=mode,
+        version_number_override=version_number_override,
+        settings=app_settings,
+    )
 
     try:
         returned = list(
@@ -325,92 +406,8 @@ def _calibrate_for_date(
     finally:
         calibrator.cleanup()
 
-    if not returned:
-        raise ValueError("Calibration produced no files to save.")
-
-    # Resolve a path handler for every returned file. The selector raises
-    # NoProviderFoundError for any file it cannot recognise, so an unhandled
-    # file type surfaces immediately rather than being silently dropped.
-    file_handlers: dict[Path, object] = {}
-    for path in returned:
-        handler = FilePathHandlerSelector.find_by_path(path)
-        if version_number_override is not None and isinstance(
-            handler, VersionedPathHandler
-        ):
-            handler.allow_overwrite = True
-        file_handlers[path] = handler
-
-    consumed: set[Path] = set()
-    saved_layer_paths: list[Path] = []
-
-    # Process JSON calibration-layer files first so co-versioning is preserved:
-    # adding the JSON bumps its handler's version, and the CSV is then saved with
-    # the bumped handler — both land on the same version number.
-    for path in returned:
-        handler = file_handlers[path]
-        if not isinstance(handler, CalibrationLayerPathHandler):
-            continue
-        if handler.extension != "json":
-            continue
-
-        layer = CalibrationLayer.from_file(path, load_contents=False)
-        if not layer.metadata.data_filename:
-            raise FileNotFoundError(
-                f"Calibration layer file at {path!s} has no data_filename in its metadata."
-            )
-
-        companion_path = next(
-            (p for p in returned if p.name == layer.metadata.data_filename.name),
-            None,
-        )
-        if companion_path is None or not companion_path.exists():
-            raise FileNotFoundError(
-                f"Calibration layer file at {path!s} has data file "
-                f"{layer.metadata.data_filename!s} that was not found among the "
-                "calibration outputs."
-            )
-        if companion_path.name != layer.metadata.data_filename.name:
-            raise ValueError(
-                f"Calibration layer metadata file {path!s} specifies data file "
-                f"{layer.metadata.data_filename!s} but matched data file is "
-                f"{companion_path!s}."
-            )
-
-        # Enforce pipeline metadata (ensures hash is correct).
-        layer.save_calibration_layer(path, createDirectory=False, save_contents=False)
-
-        (saved_json, _) = outputManager.add_file(path, path_handler=handler)
-        saved_layer_paths.append(saved_json)
-        consumed.add(path)
-
-        # Save the companion CSV using the handler derived from the JSON handler
-        # after add_file may have bumped its version — preserving co-versioning.
-        outputManager.add_file(
-            companion_path,
-            path_handler=handler.get_equivalent_data_handler(),
-        )
-        consumed.add(companion_path)
-
-    # Save any remaining files (extra products beyond the layer pair).
-    for path in returned:
-        if path in consumed:
-            continue
-        handler = file_handlers[path]
-        # Re-save if this is an additional JSON layer (keeps metadata consistent).
-        if (
-            isinstance(handler, CalibrationLayerPathHandler)
-            and handler.extension == "json"
-        ):
-            extra_layer = CalibrationLayer.from_file(path, load_contents=False)
-            extra_layer.save_calibration_layer(
-                path, createDirectory=False, save_contents=False
-            )
-        outputManager.add_file(path, path_handler=handler)
-        consumed.add(path)
-
-    logger.info(
-        f"Calibration complete for {start_date.strftime('%Y-%m-%d')} ({mode.value}): "
-        f"{len(saved_layer_paths)} layer(s) written to datastore."
+    return _save_calibration_outputs(
+        returned=returned,
+        outputManager=outputManager,
+        version_number_override=version_number_override,
     )
-
-    return saved_layer_paths

--- a/src/imap_mag/cli/process.py
+++ b/src/imap_mag/cli/process.py
@@ -17,7 +17,7 @@ from imap_mag.process import FileProcessor, dispatch
 logger = logging.getLogger(__name__)
 
 
-# E.g., imap-mag process solo_L2_mag-rtn-ll-internal_20240210_V00.cdf --save-mode localanddatabase
+# E.g., imap-mag process somefile.cdf --save-mode localanddatabase
 def process(
     files: Annotated[
         list[Path],

--- a/src/imap_mag/io/DBIndexedDatastoreFileManager.py
+++ b/src/imap_mag/io/DBIndexedDatastoreFileManager.py
@@ -305,6 +305,34 @@ class DBIndexedDatastoreFileManager(IDatastoreFileManager):
                 path_handler.set_sequence(matching_files[0].version)
             return True
 
+        # Version override: keep the forced version (no max+1 walk). Resolve any
+        # unique-constraint conflict by soft-deleting active DB records that share
+        # the same minor version but a different path — those represent the file
+        # being overwritten at the operator-supplied version.
+        if getattr(path_handler, "allow_overwrite", False):
+            forced_minor = path_handler.get_sequence()
+            new_destination = path_handler.get_full_path(self.__settings.data_store)
+            conflicting = [
+                f
+                for f in database_files
+                if f.version == forced_minor
+                and f.path
+                != File.get_datastore_relative_path(
+                    new_destination, self.__settings, warn=False
+                )
+            ]
+            for conflict in conflicting:
+                conflict_path = conflict.get_full_path(self.__settings)
+                logger.warning(
+                    f"Version override: soft-deleting conflicting DB record for "
+                    f"{conflict.path} (same minor version {forced_minor})."
+                )
+                conflict.set_deleted()
+                self.__database.upsert_file(conflict)
+                if conflict_path.exists():
+                    conflict_path.unlink()
+            return False
+
         # Assign max+1 rather than the first available slot so version numbers are
         # monotonically increasing even when earlier versions have been deleted or
         # never existed (e.g. existing versions {2} → next is 3, not 1).

--- a/src/imap_mag/io/DatastoreFileManager.py
+++ b/src/imap_mag/io/DatastoreFileManager.py
@@ -124,6 +124,20 @@ class DatastoreFileManager(IDatastoreFileManager):
         else:
             assert isinstance(path_handler, SequenceablePathHandler)
 
+        # Version override: skip up-versioning and overwrite the exact version in place.
+        if getattr(path_handler, "allow_overwrite", False):
+            if not destination_file.exists():
+                return False
+            orig_identity = path_handler.get_content_identity(original_file)
+            dest_identity = path_handler.get_content_identity(destination_file)
+            if orig_identity == dest_identity:
+                return True
+            logger.warning(
+                f"Version override active: overwriting existing file {destination_file} "
+                f"at version {path_handler.get_sequence()} with different content."
+            )
+            return False
+
         while True:
             if destination_file.exists():
                 orig_identity = path_handler.get_content_identity(original_file)

--- a/src/imap_mag/io/DatastoreFileManager.py
+++ b/src/imap_mag/io/DatastoreFileManager.py
@@ -4,7 +4,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from imap_mag.db.Database import Database
-from imap_mag.io.file import IFilePathHandler, SequenceablePathHandler
+from imap_mag.io.file.IFilePathHandler import IFilePathHandler
+from imap_mag.io.file.SequenceablePathHandler import SequenceablePathHandler
 from imap_mag.io.IDatastoreFileManager import IDatastoreFileManager, T
 from imap_mag.util.diskSpace import check_disk_space
 

--- a/src/imap_mag/io/DatastoreFileManager.py
+++ b/src/imap_mag/io/DatastoreFileManager.py
@@ -108,7 +108,10 @@ class DatastoreFileManager(IDatastoreFileManager):
         original_file: Path,
         path_handler: IFilePathHandler,
     ) -> bool:
-        """Find a viable version for a file."""
+        """Find a viable version for a file for increasing the version number on the handler until the next available version number has been found.
+
+        Returns True if the file already exists and is the same as the original file, False otherwise.
+        """
 
         destination_file: Path = path_handler.get_full_path(self.location)
 

--- a/src/imap_mag/io/FilePathHandlerSelector.py
+++ b/src/imap_mag/io/FilePathHandlerSelector.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Literal, overload
 
 from imap_mag.io.file.AncillaryPathHandler import AncillaryPathHandler
+from imap_mag.io.file.CalculatedOffsetsPathHandler import CalculatedOffsetsPathHandler
 from imap_mag.io.file.CalibrationLayerPathHandler import (
     CalibrationLayerPathHandler,
 )
@@ -51,6 +52,7 @@ class FilePathHandlerSelector:
         # Providers to try in alphabetical order.
         provider_to_try: list[type[IFilePathHandler]] = [
             AncillaryPathHandler,
+            CalculatedOffsetsPathHandler,
             CalibrationLayerPathHandler,
             HKBinaryPathHandler,
             HKDecodedPathHandler,

--- a/src/imap_mag/io/FilePathHandlerSelector.py
+++ b/src/imap_mag/io/FilePathHandlerSelector.py
@@ -49,10 +49,13 @@ class FilePathHandlerSelector:
     ) -> IFilePathHandler | None:
         """Find a suitable path handler for the given filepath."""
 
-        # Providers to try in alphabetical order.
+        # Providers to try: more-specific handlers first so they are not shadowed
+        # by broader ones. CalculatedOffsetsPathHandler is more specific than
+        # AncillaryPathHandler (it also checks the parent folder name), so it
+        # must be tried first.
         provider_to_try: list[type[IFilePathHandler]] = [
-            AncillaryPathHandler,
             CalculatedOffsetsPathHandler,
+            AncillaryPathHandler,
             CalibrationLayerPathHandler,
             HKBinaryPathHandler,
             HKDecodedPathHandler,

--- a/src/imap_mag/io/file/CalculatedOffsetsPathHandler.py
+++ b/src/imap_mag/io/file/CalculatedOffsetsPathHandler.py
@@ -3,7 +3,6 @@ import re
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import ClassVar
 
 from imap_mag.io.file.VersionedPathHandler import VersionedPathHandler
 
@@ -15,6 +14,14 @@ SPIN_PLANE = "spin_plane"  # spin-averaged offsets
 SPIN_OPTIMISED = "spin_optimised"  # spin-tone-corrected ("optimised") offsets
 OFFSET_TYPES = (SPIN_PLANE, SPIN_OPTIMISED)
 
+# Each offset type has its own file-name descriptor so the two products are uniquely
+# named (and not just distinguished by their folder). This mirrors what MATLAB writes.
+_DESCRIPTOR_BY_OFFSET_TYPE = {
+    SPIN_PLANE: "spin-plane-offsets",
+    SPIN_OPTIMISED: "spin-plane-optimised-offsets",
+}
+_OFFSET_TYPE_BY_DESCRIPTOR = {v: k for k, v in _DESCRIPTOR_BY_OFFSET_TYPE.items()}
+
 
 @dataclass
 class CalculatedOffsetsPathHandler(VersionedPathHandler):
@@ -22,11 +29,11 @@ class CalculatedOffsetsPathHandler(VersionedPathHandler):
 
     These live in ``calibration/calculated_offsets/<offset_type>/`` where
     ``offset_type`` is ``spin_plane`` (spin-averaged offsets) or ``spin_optimised``
-    (spin-tone-corrected offsets). The scripted-L2 MATLAB calibration writes one CSV
-    per sensor per day into each folder. The file name is identical in both folders,
-    so the folder (``offset_type``) is what distinguishes the two products.
+    (spin-tone-corrected offsets). Each offset type has a distinct file-name
+    descriptor so the two products are uniquely named:
 
-    File names look like ``imap_mag_mago-spin-plane-offsets_20260114_v024.csv``.
+    - ``spin_plane``     -> ``imap_mag_<sensor>-spin-plane-offsets_<date>_vNNN.csv``
+    - ``spin_optimised`` -> ``imap_mag_<sensor>-spin-plane-optimised-offsets_<date>_vNNN.csv``
     """
 
     mission: str = "imap"
@@ -36,7 +43,16 @@ class CalculatedOffsetsPathHandler(VersionedPathHandler):
     content_date: datetime | None = None  # date the offsets belong to
     extension: str = "csv"
 
-    DESCRIPTOR: ClassVar[str] = "spin-plane-offsets"
+    def _descriptor(self) -> str:
+        super()._check_property_values("descriptor", ["offset_type"])
+        assert self.offset_type
+
+        if self.offset_type not in _DESCRIPTOR_BY_OFFSET_TYPE:
+            raise ValueError(
+                f"Unknown offset_type '{self.offset_type}'. Expected one of "
+                f"{OFFSET_TYPES}."
+            )
+        return _DESCRIPTOR_BY_OFFSET_TYPE[self.offset_type]
 
     def get_content_date_for_indexing(self) -> datetime | None:
         return self.content_date
@@ -51,23 +67,24 @@ class CalculatedOffsetsPathHandler(VersionedPathHandler):
 
     def get_filename(self) -> str:
         super()._check_property_values(
-            "file name",
-            ["sensor", "content_date", "DESCRIPTOR", "version", "extension"],
+            "file name", ["sensor", "offset_type", "content_date"]
         )
         assert self.sensor and self.content_date
 
         return (
-            f"{self.mission}_{self.instrument}_{self.sensor}-{self.DESCRIPTOR}_"
+            f"{self.mission}_{self.instrument}_{self.sensor}-{self._descriptor()}_"
             f"{self.content_date.strftime('%Y%m%d')}_v{self.version:03d}.{self.extension}"
         )
 
     def get_unsequenced_pattern(self) -> re.Pattern:
-        super()._check_property_values("pattern", ["sensor", "content_date"])
+        super()._check_property_values(
+            "pattern", ["sensor", "offset_type", "content_date"]
+        )
         assert self.sensor and self.content_date
 
         return re.compile(
             rf"{self.mission}_{self.instrument}_{re.escape(self.sensor)}-"
-            rf"{re.escape(self.DESCRIPTOR)}_{self.content_date.strftime('%Y%m%d')}"
+            rf"{re.escape(self._descriptor())}_{self.content_date.strftime('%Y%m%d')}"
             rf"_v(?P<version>\d+)\.{self.extension}"
         )
 
@@ -77,18 +94,16 @@ class CalculatedOffsetsPathHandler(VersionedPathHandler):
     ) -> "CalculatedOffsetsPathHandler | None":
         """Instantiate from a file name.
 
-        The name alone cannot tell ``spin_plane`` from ``spin_optimised`` (both use
-        identical names in different folders), so ``offset_type`` is left unset. Use
-        :meth:`from_work_folder_file` when the containing folder is known.
+        The descriptor uniquely identifies the offset type, so ``offset_type`` is set
+        (``spin-plane-optimised-offsets`` -> ``spin_optimised``, ``spin-plane-offsets``
+        -> ``spin_plane``).
         """
-
-        if isinstance(filename, str):
-            filename = Path(filename)
-
+        # Match the more specific (optimised) descriptor first.
+        descriptors = "|".join(re.escape(d) for d in _OFFSET_TYPE_BY_DESCRIPTOR)
         match = re.match(
-            rf"imap_mag_(?P<sensor>mago|magi)-{re.escape(cls.DESCRIPTOR)}_"
+            rf"imap_mag_(?P<sensor>mago|magi)-(?P<descr>{descriptors})_"
             r"(?P<date>\d{8})_v(?P<version>\d+)\.(?P<ext>\w+)",
-            filename.name,
+            Path(filename).name,
         )
         logger.debug(
             f"Filename {filename} matches {match.groupdict(0) if match else 'nothing'} with calculated-offsets regex."
@@ -97,24 +112,21 @@ class CalculatedOffsetsPathHandler(VersionedPathHandler):
         if match is None:
             return None
 
-        offset_type = filename.parent.name
-        if offset_type not in OFFSET_TYPES:
-            return None
-
         return cls(
             sensor=match["sensor"],
+            offset_type=_OFFSET_TYPE_BY_DESCRIPTOR[match["descr"]],
             content_date=datetime.strptime(match["date"], "%Y%m%d"),
             version=int(match["version"]),
             extension=match["ext"],
-            offset_type=offset_type,
         )
 
     @classmethod
     def from_work_folder_file(cls, file: Path) -> "CalculatedOffsetsPathHandler":
         """Build a handler for a MATLAB-produced offsets CSV in the work folder.
 
-        ``offset_type`` is taken from the immediate parent folder name (``spin_plane``
-        or ``spin_optimised``); the remaining fields are parsed from the file name.
+        The offset type is derived from the file name; the immediate parent folder
+        (``spin_plane`` / ``spin_optimised``) is cross-checked against it as a guard
+        against a misplaced file.
         """
         handler = cls.from_filename(file.name)
         if handler is None:
@@ -122,12 +134,16 @@ class CalculatedOffsetsPathHandler(VersionedPathHandler):
                 f"'{file.name}' is not a recognised calculated-offsets file name."
             )
 
-        offset_type = file.parent.name
-        if offset_type not in OFFSET_TYPES:
+        folder = file.parent.name
+        if folder not in OFFSET_TYPES:
             raise ValueError(
                 f"Offsets file {file} must live in one of {OFFSET_TYPES} folders, "
-                f"got '{offset_type}'."
+                f"got '{folder}'."
+            )
+        if handler.offset_type != folder:
+            raise ValueError(
+                f"Offsets file {file} name implies offset type "
+                f"'{handler.offset_type}' but it sits in the '{folder}' folder."
             )
 
-        handler.offset_type = offset_type
         return handler

--- a/src/imap_mag/io/file/CalculatedOffsetsPathHandler.py
+++ b/src/imap_mag/io/file/CalculatedOffsetsPathHandler.py
@@ -98,12 +98,16 @@ class CalculatedOffsetsPathHandler(VersionedPathHandler):
         (``spin-plane-optimised-offsets`` -> ``spin_optimised``, ``spin-plane-offsets``
         -> ``spin_plane``).
         """
+
+        if isinstance(filename, str):
+            filename = Path(filename)
+
         # Match the more specific (optimised) descriptor first.
         descriptors = "|".join(re.escape(d) for d in _OFFSET_TYPE_BY_DESCRIPTOR)
         match = re.match(
             rf"imap_mag_(?P<sensor>mago|magi)-(?P<descr>{descriptors})_"
             r"(?P<date>\d{8})_v(?P<version>\d+)\.(?P<ext>\w+)",
-            Path(filename).name,
+            filename.name,
         )
         logger.debug(
             f"Filename {filename} matches {match.groupdict(0) if match else 'nothing'} with calculated-offsets regex."
@@ -112,38 +116,22 @@ class CalculatedOffsetsPathHandler(VersionedPathHandler):
         if match is None:
             return None
 
+        offset_type_from_folder = filename.parent.name
+        if offset_type_from_folder not in OFFSET_TYPES:
+            return None
+
+        offset_type = _OFFSET_TYPE_BY_DESCRIPTOR[match["descr"]]
+
+        if offset_type != offset_type_from_folder:
+            raise ValueError(
+                f"Offsets file {filename} name implies offset type "
+                f"'{offset_type}' but it sits in the '{offset_type_from_folder}' folder."
+            )
+
         return cls(
             sensor=match["sensor"],
-            offset_type=_OFFSET_TYPE_BY_DESCRIPTOR[match["descr"]],
+            offset_type=offset_type,
             content_date=datetime.strptime(match["date"], "%Y%m%d"),
             version=int(match["version"]),
             extension=match["ext"],
         )
-
-    @classmethod
-    def from_work_folder_file(cls, file: Path) -> "CalculatedOffsetsPathHandler":
-        """Build a handler for a MATLAB-produced offsets CSV in the work folder.
-
-        The offset type is derived from the file name; the immediate parent folder
-        (``spin_plane`` / ``spin_optimised``) is cross-checked against it as a guard
-        against a misplaced file.
-        """
-        handler = cls.from_filename(file.name)
-        if handler is None:
-            raise ValueError(
-                f"'{file.name}' is not a recognised calculated-offsets file name."
-            )
-
-        folder = file.parent.name
-        if folder not in OFFSET_TYPES:
-            raise ValueError(
-                f"Offsets file {file} must live in one of {OFFSET_TYPES} folders, "
-                f"got '{folder}'."
-            )
-        if handler.offset_type != folder:
-            raise ValueError(
-                f"Offsets file {file} name implies offset type "
-                f"'{handler.offset_type}' but it sits in the '{folder}' folder."
-            )
-
-        return handler

--- a/src/imap_mag/io/file/CalculatedOffsetsPathHandler.py
+++ b/src/imap_mag/io/file/CalculatedOffsetsPathHandler.py
@@ -1,0 +1,133 @@
+import logging
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import ClassVar
+
+from imap_mag.io.file.VersionedPathHandler import VersionedPathHandler
+
+logger = logging.getLogger(__name__)
+
+# The two datastore sub-folders (under calibration/calculated_offsets) that hold the
+# per-day spin-plane offset CSVs produced by the scripted-L2 MATLAB calibration.
+SPIN_PLANE = "spin_plane"  # spin-averaged offsets
+SPIN_OPTIMISED = "spin_optimised"  # spin-tone-corrected ("optimised") offsets
+OFFSET_TYPES = (SPIN_PLANE, SPIN_OPTIMISED)
+
+
+@dataclass
+class CalculatedOffsetsPathHandler(VersionedPathHandler):
+    """Path handler for calculated spin-plane offset CSVs.
+
+    These live in ``calibration/calculated_offsets/<offset_type>/`` where
+    ``offset_type`` is ``spin_plane`` (spin-averaged offsets) or ``spin_optimised``
+    (spin-tone-corrected offsets). The scripted-L2 MATLAB calibration writes one CSV
+    per sensor per day into each folder. The file name is identical in both folders,
+    so the folder (``offset_type``) is what distinguishes the two products.
+
+    File names look like ``imap_mag_mago-spin-plane-offsets_20260114_v024.csv``.
+    """
+
+    mission: str = "imap"
+    instrument: str = "mag"
+    sensor: str | None = None  # "mago" or "magi"
+    offset_type: str | None = None  # one of OFFSET_TYPES
+    content_date: datetime | None = None  # date the offsets belong to
+    extension: str = "csv"
+
+    DESCRIPTOR: ClassVar[str] = "spin-plane-offsets"
+
+    def get_content_date_for_indexing(self) -> datetime | None:
+        return self.content_date
+
+    def get_folder_structure(self) -> str:
+        super()._check_property_values("folder structure", ["offset_type"])
+        assert self.offset_type
+
+        return (
+            Path("calibration") / "calculated_offsets" / self.offset_type
+        ).as_posix()
+
+    def get_filename(self) -> str:
+        super()._check_property_values(
+            "file name",
+            ["sensor", "content_date", "DESCRIPTOR", "version", "extension"],
+        )
+        assert self.sensor and self.content_date
+
+        return (
+            f"{self.mission}_{self.instrument}_{self.sensor}-{self.DESCRIPTOR}_"
+            f"{self.content_date.strftime('%Y%m%d')}_v{self.version:03d}.{self.extension}"
+        )
+
+    def get_unsequenced_pattern(self) -> re.Pattern:
+        super()._check_property_values("pattern", ["sensor", "content_date"])
+        assert self.sensor and self.content_date
+
+        return re.compile(
+            rf"{self.mission}_{self.instrument}_{re.escape(self.sensor)}-"
+            rf"{re.escape(self.DESCRIPTOR)}_{self.content_date.strftime('%Y%m%d')}"
+            rf"_v(?P<version>\d+)\.{self.extension}"
+        )
+
+    @classmethod
+    def from_filename(
+        cls, filename: str | Path
+    ) -> "CalculatedOffsetsPathHandler | None":
+        """Instantiate from a file name.
+
+        The name alone cannot tell ``spin_plane`` from ``spin_optimised`` (both use
+        identical names in different folders), so ``offset_type`` is left unset. Use
+        :meth:`from_work_folder_file` when the containing folder is known.
+        """
+
+        if isinstance(filename, str):
+            filename = Path(filename)
+
+        match = re.match(
+            rf"imap_mag_(?P<sensor>mago|magi)-{re.escape(cls.DESCRIPTOR)}_"
+            r"(?P<date>\d{8})_v(?P<version>\d+)\.(?P<ext>\w+)",
+            filename.name,
+        )
+        logger.debug(
+            f"Filename {filename} matches {match.groupdict(0) if match else 'nothing'} with calculated-offsets regex."
+        )
+
+        if match is None:
+            return None
+
+        offset_type = filename.parent.name
+        if offset_type not in OFFSET_TYPES:
+            return None
+
+        return cls(
+            sensor=match["sensor"],
+            content_date=datetime.strptime(match["date"], "%Y%m%d"),
+            version=int(match["version"]),
+            extension=match["ext"],
+            offset_type=offset_type,
+        )
+
+    @classmethod
+    def from_work_folder_file(cls, file: Path) -> "CalculatedOffsetsPathHandler":
+        """Build a handler for a MATLAB-produced offsets CSV in the work folder.
+
+        ``offset_type`` is taken from the immediate parent folder name (``spin_plane``
+        or ``spin_optimised``); the remaining fields are parsed from the file name.
+        """
+        handler = cls.from_filename(file.name)
+        if handler is None:
+            raise ValueError(
+                f"'{file.name}' is not a recognised calculated-offsets file name."
+            )
+
+        offset_type = file.parent.name
+        if offset_type not in OFFSET_TYPES:
+            raise ValueError(
+                f"Offsets file {file} must live in one of {OFFSET_TYPES} folders, "
+                f"got '{offset_type}'."
+            )
+
+        handler.offset_type = offset_type
+        return handler

--- a/src/imap_mag/io/file/CalibrationLayerPathHandler.py
+++ b/src/imap_mag/io/file/CalibrationLayerPathHandler.py
@@ -76,6 +76,8 @@ class CalibrationLayerPathHandler(VersionedPathHandler):
         )
         handler.version_major = self.version_major
         handler.has_major_version = self.has_major_version
+        # Keep the companion CSV in lock-step with the JSON when overwriting.
+        handler.allow_overwrite = self.allow_overwrite
         return handler
 
     @classmethod

--- a/src/imap_mag/io/file/CalibrationLayerPathHandler.py
+++ b/src/imap_mag/io/file/CalibrationLayerPathHandler.py
@@ -5,7 +5,6 @@ from datetime import datetime
 from pathlib import Path
 from typing import ClassVar
 
-from imap_mag.config.AppSettings import AppSettings
 from imap_mag.io.file.VersionedPathHandler import VersionedPathHandler
 from imap_mag.util import ScienceMode
 from mag_toolkit.calibration.CalibrationDefinitions import CalibrationMethod
@@ -126,9 +125,9 @@ class CalibrationLayerPathHandler(VersionedPathHandler):
         cls,
         method: CalibrationMethod,
         content_date: datetime,
+        settings: "AppSettings",  # type: ignore  # noqa: F821
         mode: ScienceMode | None = None,
         version_number_override: tuple[int, int] | None = None,
-        settings: AppSettings = AppSettings(),
     ) -> "CalibrationLayerPathHandler":
 
         major_version = (

--- a/src/imap_mag/io/file/CalibrationLayerPathHandler.py
+++ b/src/imap_mag/io/file/CalibrationLayerPathHandler.py
@@ -5,7 +5,10 @@ from datetime import datetime
 from pathlib import Path
 from typing import ClassVar
 
+from imap_mag.config.AppSettings import AppSettings
 from imap_mag.io.file.VersionedPathHandler import VersionedPathHandler
+from imap_mag.util import ScienceMode
+from mag_toolkit.calibration.CalibrationDefinitions import CalibrationMethod
 
 logger = logging.getLogger(__name__)
 
@@ -16,8 +19,8 @@ class CalibrationLayerPathHandler(VersionedPathHandler):
     Path handler for calibration layers.
     Designed to handle the special internal case of calibration layers that do not obey exact SPDF conventions.
     E.g filemnames like
-        imap_mag_noop-norm-layer_20251017_v001.csv
-        imap_mag_noop-norm-layer-data_20251017_v001.csv
+        imap_mag_noop-norm-layer_20251017_v001.0001.csv
+        imap_mag_noop-norm-layer-data_20251017_v001.0001.csv
     """
 
     mission: str = "imap"
@@ -26,8 +29,7 @@ class CalibrationLayerPathHandler(VersionedPathHandler):
     extra_descriptor: str = ""
     content_date: datetime | None = None  # date data belongs to
     extension: str = "json"
-    version_major: int = 1
-    has_major_version: bool = True
+    _has_major_version: bool = True
 
     DESCRIPTOR_WILDCARD: ClassVar[str] = "*"
 
@@ -46,7 +48,7 @@ class CalibrationLayerPathHandler(VersionedPathHandler):
         super()._check_property_values("file name", ["descriptor", "content_date"])
         assert self.content_date
 
-        if self.has_major_version:
+        if self._has_major_version:
             return f"{self.mission}_{self.instrument}_{self.descriptor}-layer{self.extra_descriptor}_{self.content_date.strftime('%Y%m%d')}_v{self.version_major:03d}.{self.version:04d}.{self.extension}"
         else:
             return f"{self.mission}_{self.instrument}_{self.descriptor}-layer{self.extra_descriptor}_{self.content_date.strftime('%Y%m%d')}_v{self.version:03d}.{self.extension}"
@@ -66,6 +68,10 @@ class CalibrationLayerPathHandler(VersionedPathHandler):
             rf"{self.mission}_{self.instrument}_{full_descriptor}_{self.content_date.strftime('%Y%m%d')}_v(?:(?P<major>\d+)\.)?(?P<version>\d+)\.{self.extension}"
         )
 
+    def is_metadata_file(self) -> bool:
+        """Determine if this handler represents a metadata JSON file (true) or a data csv/cdf/arrow type file (false)."""
+        return self.extra_descriptor != "-data"
+
     def get_equivalent_data_handler(self) -> "CalibrationLayerPathHandler":
         handler = CalibrationLayerPathHandler(
             descriptor=self.descriptor,
@@ -73,11 +79,10 @@ class CalibrationLayerPathHandler(VersionedPathHandler):
             content_date=self.content_date,
             version=self.version,
             extension="csv",
+            version_major=self.version_major,
+            _has_major_version=self._has_major_version,
+            versioning_mode=self.versioning_mode,
         )
-        handler.version_major = self.version_major
-        handler.has_major_version = self.has_major_version
-        # Keep the companion CSV in lock-step with the JSON when overwriting.
-        handler.allow_overwrite = self.allow_overwrite
         return handler
 
     @classmethod
@@ -102,7 +107,7 @@ class CalibrationLayerPathHandler(VersionedPathHandler):
             has_major_version = True
         else:
             # Legacy format: _vNNN.ext
-            version_major = 1
+            version_major = 0
             version = int(match["major_or_minor"])
             has_major_version = False
 
@@ -112,8 +117,36 @@ class CalibrationLayerPathHandler(VersionedPathHandler):
             content_date=datetime.strptime(match["date"], "%Y%m%d"),
             version=version,
             version_major=version_major,
-            has_major_version=has_major_version,
+            _has_major_version=has_major_version,
             extension=match["ext"],
+        )
+
+    @classmethod
+    def from_method(
+        cls,
+        method: CalibrationMethod,
+        content_date: datetime,
+        mode: ScienceMode | None = None,
+        version_number_override: tuple[int, int] | None = None,
+        settings: AppSettings = AppSettings(),
+    ) -> "CalibrationLayerPathHandler":
+
+        major_version = (
+            version_number_override[0]
+            if version_number_override
+            else settings.version_major
+        )
+
+        return CalibrationLayerPathHandler(
+            descriptor=f"{method.short_name}-{mode.value}"
+            if mode is not None
+            else method.short_name,
+            content_date=content_date,
+            version_major=major_version,
+            version=version_number_override[1] if version_number_override else 1,
+            versioning_mode=VersionedPathHandler.VersionMode.USER_OVERRIDE
+            if version_number_override
+            else VersionedPathHandler.VersionMode.MAX_VERSION_PLUS_ONE,
         )
 
     def increase_sequence(self) -> None:

--- a/src/imap_mag/io/file/VersionedPathHandler.py
+++ b/src/imap_mag/io/file/VersionedPathHandler.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from enum import Enum
 
 from imap_mag.io.file.SequenceablePathHandler import SequenceablePathHandler
 
@@ -11,25 +12,36 @@ class VersionedPathHandler(SequenceablePathHandler):
     This class defines the interface for all path handlers that support versioning.
     """
 
+    class VersionMode(Enum):
+        MAX_VERSION_PLUS_ONE = "auto"
+        USER_OVERRIDE = "user_override"
+
     version: int = 1
     version_major: int = 0
     # When True the datastore managers skip version up-versioning and overwrite any
     # existing file at this exact version. Only set for the user version override; the
     # normal operating default keeps auto-versioning and overwrite protection.
-    allow_overwrite: bool = False
+    versioning_mode: VersionMode = VersionMode.MAX_VERSION_PLUS_ONE
+
+    def supports_sequencing(self) -> bool:
+        """Denotes whether this path handler supports sequence-like indexes."""
+        return (
+            self.versioning_mode
+            == VersionedPathHandler.VersionMode.MAX_VERSION_PLUS_ONE
+        )
 
     def get_sequence(self) -> int:
         return self.version
 
     def set_sequence(self, sequence: int) -> None:
         if not self.supports_sequencing():
-            raise ValueError("This path handler does not support sequencing.")
+            raise ValueError("This file does not support changing version/sequence. ")
 
         self.version = sequence
 
     def increase_sequence(self) -> None:
         if not self.supports_sequencing():
-            raise ValueError("This path handler does not support sequencing.")
+            raise ValueError("This file does not support changing version/sequence. ")
 
         self.version += 1
 

--- a/src/imap_mag/io/file/VersionedPathHandler.py
+++ b/src/imap_mag/io/file/VersionedPathHandler.py
@@ -13,6 +13,10 @@ class VersionedPathHandler(SequenceablePathHandler):
 
     version: int = 1
     version_major: int = 0
+    # When True the datastore managers skip version up-versioning and overwrite any
+    # existing file at this exact version. Only set for the user version override; the
+    # normal operating default keeps auto-versioning and overwrite protection.
+    allow_overwrite: bool = False
 
     def get_sequence(self) -> int:
         return self.version

--- a/src/imap_mag/io/file/__init__.py
+++ b/src/imap_mag/io/file/__init__.py
@@ -1,4 +1,7 @@
 from imap_mag.io.file.AncillaryPathHandler import AncillaryPathHandler
+from imap_mag.io.file.CalculatedOffsetsPathHandler import (
+    CalculatedOffsetsPathHandler,
+)
 from imap_mag.io.file.CalibrationLayerPathHandler import (
     CalibrationLayerPathHandler,
 )
@@ -20,6 +23,7 @@ from imap_mag.io.file.VersionedPathHandler import VersionedPathHandler
 
 __all__ = [
     "AncillaryPathHandler",
+    "CalculatedOffsetsPathHandler",
     "CalibrationLayerPathHandler",
     "HKBinaryPathHandler",
     "HKDecodedPathHandler",

--- a/src/imap_mag/process/dispatch.py
+++ b/src/imap_mag/process/dispatch.py
@@ -1,7 +1,7 @@
 import logging
 from pathlib import Path
 
-from imap_mag.io import FileFinder
+from imap_mag.io.FileFinder import FileFinder
 from imap_mag.process.FileProcessor import FileProcessor
 from imap_mag.process.HKProcessor import HKProcessor
 

--- a/src/mag_toolkit/calibration/CalibrationConfig.py
+++ b/src/mag_toolkit/calibration/CalibrationConfig.py
@@ -58,6 +58,7 @@ class ScriptedL2CalibrationConfig(CalibrationConfig):
     input_json_file: str
     datastore_access_mode: DatastoreAccessMode = DatastoreAccessMode.READ_DIRECTLY
     matlab_repo: str
+    produce_report: bool = False
 
     @classmethod
     def get_method(cls) -> CalibrationMethod:

--- a/src/mag_toolkit/calibration/CalibrationLayer.py
+++ b/src/mag_toolkit/calibration/CalibrationLayer.py
@@ -11,6 +11,7 @@ from cdflib.xarray import cdf_to_xarray, xarray_to_cdf
 from pydantic import PrivateAttr
 
 from imap_mag import get_version
+from imap_mag.config import AppSettings
 from imap_mag.io.file import CalibrationLayerPathHandler, IFilePathHandler
 from mag_toolkit.calibration.CalibrationDefinitions import (
     CONSTANTS,
@@ -345,7 +346,9 @@ class CalibrationLayer(Layer):
         return instance
 
     @classmethod
-    def create_zero_offset_layer_from_science(cls, science_layer: ScienceLayer):
+    def create_zero_offset_layer_from_science(
+        cls, science_layer: ScienceLayer, settings: AppSettings = AppSettings()
+    ) -> "CalibrationLayer":
         if not science_layer:
             raise ValueError(
                 "Science layer must be provided to create zero offset layer."
@@ -383,8 +386,10 @@ class CalibrationLayer(Layer):
         )
         datefilename = None
         if content_date:
-            calibration_handler = CalibrationLayerPathHandler(
-                descriptor=CalibrationMethod.NOOP.short_name, content_date=content_date
+            calibration_handler = CalibrationLayerPathHandler.from_method(
+                method=CalibrationMethod.NOOP,
+                content_date=content_date,
+                settings=settings,
             )
             datefilehandler = calibration_handler.get_equivalent_data_handler()
             datefilename = Path(datefilehandler.get_filename())

--- a/src/mag_toolkit/calibration/MatlabWrapper.py
+++ b/src/mag_toolkit/calibration/MatlabWrapper.py
@@ -191,14 +191,15 @@ def call_matlab(
                 line = line[len("CRITICAL: ") :]
                 log_method = logger.critical
 
-            # Capture the MATLAB output after the first "ans =" line, which is the start of the function's return value.
-            # only log these lines to debug since they are logged anyway after the process finishes.
+            # Capture the MATLAB output after the "ans =" line, which is (probably) the start of the function's return value.
+            # If we see more than one `ans =` lines, we will discard all but the last one, which is probably the return value of the function.
             if started_answering and line:
                 answer_lines.append(line)
                 log_method = logger.debug
 
             if line.startswith("ans ="):
                 started_answering = True  # next and later lines are collected
+                answer_lines = []  # reset answer lines to only capture the last ans = output
                 log_method = logger.debug
 
             if line:

--- a/src/mag_toolkit/calibration/MatlabWrapper.py
+++ b/src/mag_toolkit/calibration/MatlabWrapper.py
@@ -99,8 +99,12 @@ def call_matlab(
     timeout=60 * 5,
     cwd: Path | str | None = None,
     include_project_paths: bool = True,
-):
+) -> list[str]:
     """Run a MATLAB batch command, folding project path setup into the first call.
+
+    Returns the ans= output lines from MATLAB as a list of strings.
+    If function output is a single string, the list will contain one string with quotes stripped.
+    If function output is a 1d cell array, the list will contain one string with the array as a whole string.
 
     When ``include_project_paths`` is True and the imap-mag project paths have not
     yet been set up in this process, the ``addpath``/``savepath`` preamble is
@@ -166,6 +170,8 @@ def call_matlab(
         preexec_fn=_set_parent_death_signal_linux if os.name == "posix" else None,
     )
 
+    answer_lines: list[str] = []
+    started_answering = False
     try:
         while (line := p.stdout.readline()) != "":  # type: ignore
             line = line.rstrip()
@@ -185,8 +191,15 @@ def call_matlab(
                 line = line[len("CRITICAL: ") :]
                 log_method = logger.critical
 
+            if started_answering:
+                answer_lines.append(line)
+                log_method = logger.debug
+
             if line:
                 log_method(line)
+
+            if line.startswith("ans ="):
+                started_answering = True  # next lines are collected
 
         p.wait(timeout=timeout)
     except (subprocess.TimeoutExpired, KeyboardInterrupt):
@@ -208,4 +221,18 @@ def call_matlab(
         logger.error(f"MATLAB command failed with return code {p.returncode}")
         raise RuntimeError(f"MATLAB command failed with return code {p.returncode}")
 
+    answer_lines = [
+        line.strip().strip('"') for line in answer_lines if line.strip()
+    ]  # remove empty lines and whitespace
+
+    if len(answer_lines) > 0:
+        logger.info(
+            "Result from MATLAB command: ("
+            + str(len(answer_lines))
+            + " line(s))\n"
+            + "\n".join(answer_lines)
+        )
+
     logger.info(f"MATLAB process finished with return code {p.returncode}")
+
+    return answer_lines

--- a/src/mag_toolkit/calibration/MatlabWrapper.py
+++ b/src/mag_toolkit/calibration/MatlabWrapper.py
@@ -191,15 +191,18 @@ def call_matlab(
                 line = line[len("CRITICAL: ") :]
                 log_method = logger.critical
 
-            if started_answering:
+            # Capture the MATLAB output after the first "ans =" line, which is the start of the function's return value.
+            # only log these lines to debug since they are logged anyway after the process finishes.
+            if started_answering and line:
                 answer_lines.append(line)
+                log_method = logger.debug
+
+            if line.startswith("ans ="):
+                started_answering = True  # next and later lines are collected
                 log_method = logger.debug
 
             if line:
                 log_method(line)
-
-            if line.startswith("ans ="):
-                started_answering = True  # next lines are collected
 
         p.wait(timeout=timeout)
     except (subprocess.TimeoutExpired, KeyboardInterrupt):

--- a/src/mag_toolkit/calibration/__init__.py
+++ b/src/mag_toolkit/calibration/__init__.py
@@ -10,28 +10,18 @@ from .CalibrationDefinitions import (
 )
 from .CalibrationJobParameters import CalibrationJobParameters
 from .CalibrationLayer import CalibrationLayer
-from .calibrators import (
-    CalibrationJob,
-    GradiometerCalibrationJob,
-    ScriptedL2CalibrationJob,
-    SetQualityAndNaNCalibrationJob,
-)
 from .ScienceLayer import ScienceLayer
 
 __all__ = [
     "CalibrationApplicator",
-    "CalibrationJob",
     "CalibrationJobParameters",
     "CalibrationLayer",
     "CalibrationMetadata",
     "CalibrationMethod",
     "CalibrationValue",
     "DatastoreAccessMode",
-    "GradiometerCalibrationJob",
     "Mission",
     "ScienceLayer",
     "ScienceValue",
-    "ScriptedL2CalibrationJob",
     "Sensor",
-    "SetQualityAndNaNCalibrationJob",
 ]

--- a/src/mag_toolkit/calibration/calibrators/CalibrationJob.py
+++ b/src/mag_toolkit/calibration/calibrators/CalibrationJob.py
@@ -1,14 +1,19 @@
+from __future__ import annotations
+
 import logging
 import shutil
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from imap_mag.cli.cliUtils import fetch_file_for_work
-from imap_mag.io.file import CalibrationLayerPathHandler
-from imap_mag.io.FileFinder import FileFinder
 from mag_toolkit.calibration.CalibrationConfig import CalibrationConfig
 from mag_toolkit.calibration.CalibrationJobParameters import CalibrationJobParameters
+
+if TYPE_CHECKING:
+    from imap_mag.io.file import CalibrationLayerPathHandler
+    from imap_mag.io.FileFinder import FileFinder
 
 logger = logging.getLogger(__name__)
 

--- a/src/mag_toolkit/calibration/calibrators/CalibrationJob.py
+++ b/src/mag_toolkit/calibration/calibrators/CalibrationJob.py
@@ -1,6 +1,7 @@
 import logging
 import shutil
 from abc import ABC, abstractmethod
+from collections.abc import Sequence
 from pathlib import Path
 
 from imap_mag.cli.cliUtils import fetch_file_for_work
@@ -124,5 +125,5 @@ class CalibrationJob(ABC):
     @abstractmethod
     def run_calibration(
         self, cal_handler: CalibrationLayerPathHandler, config: CalibrationConfig
-    ) -> tuple[Path, Path]:
+    ) -> Sequence[Path]:
         """Calibration that generates a calibration layer."""

--- a/src/mag_toolkit/calibration/calibrators/ScriptedL2Calibration.py
+++ b/src/mag_toolkit/calibration/calibrators/ScriptedL2Calibration.py
@@ -269,6 +269,7 @@ class ScriptedL2CalibrationJob(CalibrationJob):
             "l2_pre_calibration_outputs": output_dir_path,
             "report_folder": str(datastore_path / "calibration" / "reports"),
             "output_layers_folder": output_dir_path,
+            "output_offsets_folder": output_dir_path,
         }
 
         user_config_path = self.work_folder / USER_CONFIG_FILENAME

--- a/src/mag_toolkit/calibration/calibrators/ScriptedL2Calibration.py
+++ b/src/mag_toolkit/calibration/calibrators/ScriptedL2Calibration.py
@@ -111,12 +111,6 @@ class ScriptedL2CalibrationJob(CalibrationJob):
         date = self.calibration_job_parameters.date
         mode = self.calibration_job_parameters.mode
 
-        # Pass the (major, minor) version pair to MATLAB so it owns filename construction.
-        # MATLAB builds names like imap_mag_manual-<mode>-layer_<YYYYMMDD>_v<major>.<minor>.json
-        # using these values, which CalibrationLayerPathHandler.from_filename can parse back.
-        output_version_major = cal_handler.version_major
-        output_version_minor = cal_handler.version
-
         # Use a dedicated output subfolder so MATLAB writes only its products there.
         # Recreate it empty on each run to prevent stale outputs from a previous
         # cleanup_temp_files_after_run=False run leaking into the returned file list.
@@ -131,7 +125,6 @@ class ScriptedL2CalibrationJob(CalibrationJob):
 
         # Decide which datastore MATLAB will read from, building a sparse local copy
         # in the work folder if requested.
-        sparse_datastore: Path | None = None
         if config.datastore_access_mode == DatastoreAccessMode.LOCAL_WORK_FOLDER_COPY:
             sparse_datastore = self._build_sparse_datastore(
                 date, mode, metakernel_filename, config.calibration_matrix_version
@@ -139,6 +132,7 @@ class ScriptedL2CalibrationJob(CalibrationJob):
             matlab_datastore = sparse_datastore
             self._paths_needing_cleanup.append(sparse_datastore)
         else:
+            assert self.data_store is not None
             matlab_datastore = self.data_store
 
         user_config_path = self._write_user_config(matlab_datastore, output_dir)
@@ -148,12 +142,11 @@ class ScriptedL2CalibrationJob(CalibrationJob):
             date=date,
             calibration_matrix_version=config.calibration_matrix_version,
             metakernel_filename=metakernel_filename,
-            output_data_version=output_version_minor,
-            output_version_major=output_version_major,
-            output_version_minor=output_version_minor,
+            output_data_version=(cal_handler.version_major, cal_handler.version),
             input_json_file=config.input_json_file,
             user_config_path=user_config_path,
             matlab_mode=str(mode.value),
+            produce_report=config.produce_report,
         )
 
         call_matlab(
@@ -164,6 +157,11 @@ class ScriptedL2CalibrationJob(CalibrationJob):
         )
 
         produced = sorted(p for p in output_dir.rglob("*") if p.is_file())
+
+        logger.info(
+            f"MATLAB calibration produced {len(produced)} output files in {output_dir}"
+        )
+
         if not produced:
             raise FileNotFoundError(
                 f"MATLAB calibration produced no output files in {output_dir}."
@@ -288,12 +286,11 @@ class ScriptedL2CalibrationJob(CalibrationJob):
         date: datetime,
         calibration_matrix_version: int,
         metakernel_filename: str,
-        output_data_version: int,
-        output_version_major: int,
-        output_version_minor: int,
+        output_data_version: tuple[int, int],
         input_json_file: str,
         user_config_path: Path,
         matlab_mode: str,
+        produce_report: bool,
     ) -> str:
         """Build the ``calibrate_l2_offsets`` MATLAB command for a single day.
 
@@ -302,10 +299,7 @@ class ScriptedL2CalibrationJob(CalibrationJob):
             calibration_matrix_version: Version of the calibration matrices to load.
             metakernel_filename: Bare filename of the SPICE metakernel MATLAB should
                 furnish (looked up under ``{datastore}/spice/mk/``).
-            output_data_version: Data-product (minor) version for the L2-pre CDF and
-                diagnostic report file names MATLAB produces.
-            output_version_major: Major version number for MATLAB layer file naming.
-            output_version_minor: Minor version number for MATLAB layer file naming.
+            output_data_version: Tuple of (major, minor) version numbers for MATLAB layer file naming.
             input_json_file: Path (relative to the MATLAB repo) of the calibration
                 input configuration JSON.
             user_config_path: Path to the generated MATLAB user/env file-path config.
@@ -318,10 +312,9 @@ class ScriptedL2CalibrationJob(CalibrationJob):
             f"{date_expr}, {date_expr}, "
             f"{calibration_matrix_version}, "
             f'"{metakernel_filename}", '
-            f"{output_data_version}, "
+            f"[{output_data_version[0]}, {output_data_version[1]}], "
             f'"{input_json_file}", '
             f'"{user_config_path.resolve()!s}", '
             f'modes=["{matlab_mode}"], '
-            f"output_version=[{output_version_major} {output_version_minor}], "
-            "publish_to_sharepoint=false,display_plots=false,spice_transform_and_write=false)"
+            f"publish_to_sharepoint=false,display_plots=false,spice_transform_and_write=false,produce_report={'true' if produce_report else 'false'})"
         )

--- a/src/mag_toolkit/calibration/calibrators/ScriptedL2Calibration.py
+++ b/src/mag_toolkit/calibration/calibrators/ScriptedL2Calibration.py
@@ -31,6 +31,12 @@ USER_CONFIG_FILENAME = "imap_mag_scripted_l2_file_path_config.json"
 # DatastoreAccessMode.LOCAL_WORK_FOLDER_COPY.
 SPARSE_DATASTORE_FOLDER_NAME = "sparse_datastore"
 
+# Subfolder of the work folder where MATLAB writes its output files. Using a
+# dedicated subfolder keeps outputs separate from the user-config JSON and the
+# sparse datastore, and lets run_calibration collect exactly what MATLAB produced
+# by scanning this one directory (no filename prediction needed).
+OUTPUT_SUBFOLDER_NAME = "outputs"
+
 # Relative path (within the MATLAB repo) of the script we invoke. Used to fail fast
 # if the acquired repo does not actually contain the expected entry point.
 MATLAB_SCRIPT_RELATIVE_PATH = (
@@ -90,7 +96,7 @@ class ScriptedL2CalibrationJob(CalibrationJob):
 
     def run_calibration(
         self, cal_handler: CalibrationLayerPathHandler, config: CalibrationConfig
-    ) -> tuple[Path, Path]:
+    ) -> list[Path]:
         if not isinstance(config, ScriptedL2CalibrationConfig):
             raise TypeError(
                 "ScriptedL2CalibrationJob requires a ScriptedL2CalibrationConfig, "
@@ -104,14 +110,22 @@ class ScriptedL2CalibrationJob(CalibrationJob):
 
         date = self.calibration_job_parameters.date
         mode = self.calibration_job_parameters.mode
-        output_data_version = cal_handler.version
 
-        # imap-pipeline-core owns the layer file naming (it decides the major/minor
-        # version). Pass the exact layer JSON and companion CSV file names to MATLAB
-        # so the files it writes match what this job then looks for in the work folder.
-        # MATLAB falls back to its own default names when these are not provided.
-        output_layer_filename = cal_handler.get_filename()
-        output_data_filename = cal_handler.get_equivalent_data_handler().get_filename()
+        # Pass the (major, minor) version pair to MATLAB so it owns filename construction.
+        # MATLAB builds names like imap_mag_manual-<mode>-layer_<YYYYMMDD>_v<major>.<minor>.json
+        # using these values, which CalibrationLayerPathHandler.from_filename can parse back.
+        output_version_major = cal_handler.version_major
+        output_version_minor = cal_handler.version
+
+        # Use a dedicated output subfolder so MATLAB writes only its products there.
+        # Recreate it empty on each run to prevent stale outputs from a previous
+        # cleanup_temp_files_after_run=False run leaking into the returned file list.
+        output_dir = self.work_folder / OUTPUT_SUBFOLDER_NAME
+        if output_dir.exists():
+            import shutil as _shutil
+
+            _shutil.rmtree(output_dir)
+        output_dir.mkdir(parents=True)
 
         metakernel_filename = self._resolve_metakernel(date)
 
@@ -127,19 +141,19 @@ class ScriptedL2CalibrationJob(CalibrationJob):
         else:
             matlab_datastore = self.data_store
 
-        user_config_path = self._write_user_config(matlab_datastore)
+        user_config_path = self._write_user_config(matlab_datastore, output_dir)
         self._paths_needing_cleanup.append(user_config_path)
 
         command = self._build_matlab_command(
             date=date,
             calibration_matrix_version=config.calibration_matrix_version,
             metakernel_filename=metakernel_filename,
-            output_data_version=output_data_version,
+            output_data_version=output_version_minor,
+            output_version_major=output_version_major,
+            output_version_minor=output_version_minor,
             input_json_file=config.input_json_file,
             user_config_path=user_config_path,
             matlab_mode=str(mode.value),
-            output_layer_filename=output_layer_filename,
-            output_data_filename=output_data_filename,
         )
 
         call_matlab(
@@ -149,21 +163,13 @@ class ScriptedL2CalibrationJob(CalibrationJob):
             timeout=self._timeout_seconds(mode),
         )
 
-        calfile = self.work_folder / cal_handler.get_filename()
-        datafile = (
-            self.work_folder / cal_handler.get_equivalent_data_handler().get_filename()
-        )
-
-        if not calfile.exists():
+        produced = sorted(p for p in output_dir.rglob("*") if p.is_file())
+        if not produced:
             raise FileNotFoundError(
-                f"Calibration layer file {calfile} was not created by the MATLAB calibration."
-            )
-        if not datafile.exists():
-            raise FileNotFoundError(
-                f"Calibration data file {datafile} was not created by the MATLAB calibration."
+                f"MATLAB calibration produced no output files in {output_dir}."
             )
 
-        return calfile, datafile
+        return produced
 
     def _timeout_seconds(self, mode: ScienceMode) -> int:
         """MATLAB timeout for a single day of the given mode.
@@ -244,23 +250,27 @@ class ScriptedL2CalibrationJob(CalibrationJob):
         logger.info(f"Generated and published metakernel {filename} to {mk_path}")
         return filename
 
-    def _write_user_config(self, matlab_datastore: Path) -> Path:
+    def _write_user_config(self, matlab_datastore: Path, output_dir: Path) -> Path:
         """Write the MATLAB user/env file-path config JSON to the work folder.
 
         ``sharepoint_flight_data`` and ``spice_metakernal_root`` point at the
-        datastore root MATLAB should read (the real datastore, or the sparse copy),
-        while the three output folders map to the work folder so MATLAB writes there
-        rather than into the datastore.
+        datastore root MATLAB should read (the real datastore, or the sparse copy).
+        Both output folders (``output_layers_folder`` and ``l2_pre_calibration_outputs``)
+        map to the dedicated output subfolder so MATLAB writes only its products there.
+
+        Args:
+            matlab_datastore: Root of the datastore MATLAB should read from.
+            output_dir: Dedicated output subfolder where MATLAB writes its products.
         """
         datastore_path = Path(matlab_datastore).resolve()
-        work_folder_path = str(self.work_folder.resolve())
+        output_dir_path = str(output_dir.resolve())
 
         config = {
             "sharepoint_flight_data": str(datastore_path),
             "spice_metakernal_root": str(datastore_path),
-            "l2_pre_calibration_outputs": work_folder_path,
+            "l2_pre_calibration_outputs": output_dir_path,
             "report_folder": str(datastore_path / "calibration" / "reports"),
-            "output_layers_folder": work_folder_path,
+            "output_layers_folder": output_dir_path,
         }
 
         user_config_path = self.work_folder / USER_CONFIG_FILENAME
@@ -279,11 +289,11 @@ class ScriptedL2CalibrationJob(CalibrationJob):
         calibration_matrix_version: int,
         metakernel_filename: str,
         output_data_version: int,
+        output_version_major: int,
+        output_version_minor: int,
         input_json_file: str,
         user_config_path: Path,
         matlab_mode: str,
-        output_layer_filename: str,
-        output_data_filename: str,
     ) -> str:
         """Build the ``calibrate_l2_offsets`` MATLAB command for a single day.
 
@@ -294,14 +304,12 @@ class ScriptedL2CalibrationJob(CalibrationJob):
                 furnish (looked up under ``{datastore}/spice/mk/``).
             output_data_version: Data-product (minor) version for the L2-pre CDF and
                 diagnostic report file names MATLAB produces.
+            output_version_major: Major version number for MATLAB layer file naming.
+            output_version_minor: Minor version number for MATLAB layer file naming.
             input_json_file: Path (relative to the MATLAB repo) of the calibration
                 input configuration JSON.
             user_config_path: Path to the generated MATLAB user/env file-path config.
             matlab_mode: Science mode to process (``"norm"`` or ``"burst"``).
-            output_layer_filename: Bare filename the layer JSON must be written as, so
-                imap-pipeline-core controls the major/minor versioned name.
-            output_data_filename: Bare filename the companion layer-data CSV must be
-                written as (paired with ``output_layer_filename``).
         """
         date_expr = f"datetime({date.year},{date.month},{date.day})"
 
@@ -314,7 +322,6 @@ class ScriptedL2CalibrationJob(CalibrationJob):
             f'"{input_json_file}", '
             f'"{user_config_path.resolve()!s}", '
             f'modes=["{matlab_mode}"], '
-            f'output_layer_filename="{output_layer_filename}", '
-            f'output_data_filename="{output_data_filename}", '
+            f"output_version=[{output_version_major} {output_version_minor}], "
             "publish_to_sharepoint=false,display_plots=false,spice_transform_and_write=false)"
         )

--- a/src/prefect_server/checkIALiRT.py
+++ b/src/prefect_server/checkIALiRT.py
@@ -9,7 +9,8 @@ from prefect.runtime import flow_run
 from prefect.states import Completed, Failed
 from pydantic import Field
 
-from imap_mag.check import IALiRTAnomaly, SeverityLevel
+from imap_mag.check.IALiRTAnomaly import IALiRTAnomaly
+from imap_mag.check.SeverityLevel import SeverityLevel
 from imap_mag.cli.check.check_ialirt import check_ialirt
 from imap_mag.db import Database
 from imap_mag.util import CONSTANTS, DatetimeProvider

--- a/src/prefect_server/performCalibration.py
+++ b/src/prefect_server/performCalibration.py
@@ -336,6 +336,7 @@ def calibrate_flow(
     save_mode: SaveMode = SaveMode.LocalAndDatabase,
     metakernel: Path | None = None,
     split_by_day: SplitByDay = False,
+    version_number_override: tuple[int, int] | None = None,
 ) -> list[Path] | list[FlowRun]:
 
     if isinstance(start_date, date) and not isinstance(start_date, datetime):
@@ -359,11 +360,19 @@ def calibrate_flow(
                 "sensor": sensor,
                 "save_mode": save_mode,
                 "metakernel": metakernel,
+                "version_number_override": version_number_override,
             },
         )
 
     paths = _run_calibration(
-        configuration, start_date, end_date, mode, sensor, save_mode, metakernel
+        configuration,
+        start_date,
+        end_date,
+        mode,
+        sensor,
+        save_mode,
+        metakernel,
+        version_number_override=version_number_override,
     )
 
     if len(paths) == 0:
@@ -395,6 +404,7 @@ def calibrate_and_apply_flow(
     save_mode: SaveMode = SaveMode.LocalAndDatabase,
     metakernel: Path | None = None,
     split_by_day: SplitByDay = False,
+    version_number_override: tuple[int, int] | None = None,
 ) -> list[FlowRun] | None:
     days = _days_in_range(start_date, end_date)
     if split_by_day and len(days) > 1:
@@ -409,11 +419,19 @@ def calibrate_and_apply_flow(
                 "L2_output_type": L2_output_type,
                 "save_mode": save_mode,
                 "metakernel": metakernel,
+                "version_number_override": version_number_override,
             },
         )
 
     cal_layer_paths = _run_calibration(
-        configuration, start_date, end_date, mode, sensor, save_mode, metakernel
+        configuration,
+        start_date,
+        end_date,
+        mode,
+        sensor,
+        save_mode,
+        metakernel,
+        version_number_override=version_number_override,
     )
 
     layer = CalibrationLayer.from_file(cal_layer_paths[0])
@@ -440,6 +458,7 @@ def _run_calibration(
     save_mode,
     metakernel,
     cleanup_temp_files_after_run: bool = True,
+    version_number_override: tuple[int, int] | None = None,
 ):
     if type(configuration) is PrefectScriptedL2CalibrationConfig:
         app_settings = AppSettings()  # type: ignore
@@ -470,6 +489,7 @@ def _run_calibration(
         save_mode=save_mode,
         metakernel=metakernel,
         cleanup_temp_files_after_run=configuration.cleanup_temp_files_after_run,
+        version_number_override=version_number_override,
     )
 
     return cal_layer_paths

--- a/src/prefect_server/performCalibration.py
+++ b/src/prefect_server/performCalibration.py
@@ -329,14 +329,13 @@ def calibrate_flow(
     ] = PrefectScriptedL2CalibrationConfig(
         calibration_matrix_version=9,
         input_json_file="+calibration/calibration/[CAL_FILE_HERE].json",
-        matlab_repo="src/matlab/calibration",
+        matlab_repo="/app/matlab/calibration",
     ),
     mode: ScienceMode = ScienceMode.Normal,
     sensor: Sensor = Sensor.MAGO,
     save_mode: SaveMode = SaveMode.LocalAndDatabase,
     metakernel: Path | None = None,
     split_by_day: SplitByDay = False,
-    version_number_override: tuple[int, int] | None = None,
 ) -> list[Path] | list[FlowRun]:
 
     if isinstance(start_date, date) and not isinstance(start_date, datetime):
@@ -360,19 +359,11 @@ def calibrate_flow(
                 "sensor": sensor,
                 "save_mode": save_mode,
                 "metakernel": metakernel,
-                "version_number_override": version_number_override,
             },
         )
 
     paths = _run_calibration(
-        configuration,
-        start_date,
-        end_date,
-        mode,
-        sensor,
-        save_mode,
-        metakernel,
-        version_number_override=version_number_override,
+        configuration, start_date, end_date, mode, sensor, save_mode, metakernel
     )
 
     if len(paths) == 0:
@@ -404,7 +395,6 @@ def calibrate_and_apply_flow(
     save_mode: SaveMode = SaveMode.LocalAndDatabase,
     metakernel: Path | None = None,
     split_by_day: SplitByDay = False,
-    version_number_override: tuple[int, int] | None = None,
 ) -> list[FlowRun] | None:
     days = _days_in_range(start_date, end_date)
     if split_by_day and len(days) > 1:
@@ -419,19 +409,11 @@ def calibrate_and_apply_flow(
                 "L2_output_type": L2_output_type,
                 "save_mode": save_mode,
                 "metakernel": metakernel,
-                "version_number_override": version_number_override,
             },
         )
 
     cal_layer_paths = _run_calibration(
-        configuration,
-        start_date,
-        end_date,
-        mode,
-        sensor,
-        save_mode,
-        metakernel,
-        version_number_override=version_number_override,
+        configuration, start_date, end_date, mode, sensor, save_mode, metakernel
     )
 
     layer = CalibrationLayer.from_file(cal_layer_paths[0])
@@ -458,7 +440,6 @@ def _run_calibration(
     save_mode,
     metakernel,
     cleanup_temp_files_after_run: bool = True,
-    version_number_override: tuple[int, int] | None = None,
 ):
     if type(configuration) is PrefectScriptedL2CalibrationConfig:
         app_settings = AppSettings()  # type: ignore
@@ -489,7 +470,6 @@ def _run_calibration(
         save_mode=save_mode,
         metakernel=metakernel,
         cleanup_temp_files_after_run=configuration.cleanup_temp_files_after_run,
-        version_number_override=version_number_override,
     )
 
     return cal_layer_paths

--- a/tests/integration/test_DBIndexedDatastoreFileManager.py
+++ b/tests/integration/test_DBIndexedDatastoreFileManager.py
@@ -774,7 +774,7 @@ def test_calibration_layer_db_different_content_creates_v002_with_correct_meta(
     )
 
     path_handler = CalibrationLayerPathHandler(
-        descriptor="quality-norm", content_date=date, version=1
+        descriptor="quality-norm", content_date=date, version=1, version_major=1
     )
 
     # Capture source content during the mock call (before cleanup deletes the temp file)

--- a/tests/integration/test_nan_fill_val_propagation.py
+++ b/tests/integration/test_nan_fill_val_propagation.py
@@ -18,6 +18,7 @@ from pathlib import Path
 import pandas as pd
 
 from imap_mag.cli.apply import apply
+from imap_mag.config import AppSettings
 from imap_mag.util.ReferenceFrame import ReferenceFrame
 from mag_toolkit.calibration import CalibrationLayer, ScienceLayer
 from mag_toolkit.calibration.CalibrationDefinitions import CONSTANTS
@@ -44,7 +45,9 @@ def _set_science_cdf_fill_value(path: Path, row_index: int):
 
 def _create_noop_layer(science_cdf_path: Path, output_folder: Path, name: str = "noop"):
     science_layer = ScienceLayer.from_file(science_cdf_path, load_contents=True)
-    zero_layer = CalibrationLayer.create_zero_offset_layer_from_science(science_layer)
+    zero_layer = CalibrationLayer.create_zero_offset_layer_from_science(
+        science_layer, AppSettings()
+    )
 
     layer_json = output_folder / f"imap_mag_{name}-norm-layer_20260116_v001.json"
     zero_layer.writeToFile(layer_json)

--- a/tests/integration/test_setQualityAndNan.py
+++ b/tests/integration/test_setQualityAndNan.py
@@ -9,20 +9,20 @@ import pytest
 
 from imap_mag.cli.apply import apply
 from imap_mag.cli.calibrate import calibrate
-from imap_mag.config import SaveMode
+from imap_mag.config import AppSettings, SaveMode
 from imap_mag.io.file.CalibrationLayerPathHandler import CalibrationLayerPathHandler
 from imap_mag.util import ScienceMode
 from mag_toolkit.calibration import (
     CalibrationLayer,
     CalibrationMethod,
     Sensor,
-    SetQualityAndNaNCalibrationJob,
 )
 from mag_toolkit.calibration.CalibrationConfig import (
     SetQualityAndNaNConfig,
 )
 from mag_toolkit.calibration.CalibrationDefinitions import CONSTANTS, ValueType
 from mag_toolkit.calibration.CalibrationJobParameters import CalibrationJobParameters
+from mag_toolkit.calibration.calibrators import SetQualityAndNaNCalibrationJob
 from tests.util.database import test_database  # noqa: F401
 from tests.util.miscellaneous import open_cdf
 
@@ -55,6 +55,7 @@ def test_calibration_job_creates_quality_flag_layer_file_json_and_csv_with_corre
     cal_handler = CalibrationLayerPathHandler.from_method(
         method=CalibrationMethod.SET_QUALITY_AND_NAN,
         content_date=datetime(2026, 1, 16),
+        settings=AppSettings(),
     )
 
     job = SetQualityAndNaNCalibrationJob(params, work_folder)
@@ -103,6 +104,7 @@ def test_run_calibration_writes_epoch_as_full_iso_datetime_when_clipped_to_day_b
     handler = CalibrationLayerPathHandler.from_method(
         method=CalibrationMethod.SET_QUALITY_AND_NAN,
         content_date=datetime(2026, 1, 16),
+        settings=AppSettings(),
     )
     job = SetQualityAndNaNCalibrationJob(params, work_folder)
 
@@ -134,6 +136,7 @@ def test_calibration_job_splits_across_days(tmp_path):
     handler_day1 = CalibrationLayerPathHandler.from_method(
         method=CalibrationMethod.SET_QUALITY_AND_NAN,
         content_date=datetime(2026, 1, 16),
+        settings=AppSettings(),
     )
     job_day1 = SetQualityAndNaNCalibrationJob(params_day1, work_folder)
     _, datafile1 = job_day1.run_calibration(handler_day1, config)
@@ -154,6 +157,7 @@ def test_calibration_job_splits_across_days(tmp_path):
     handler_day2 = CalibrationLayerPathHandler.from_method(
         method=CalibrationMethod.SET_QUALITY_AND_NAN,
         content_date=datetime(2026, 1, 17),
+        settings=AppSettings(),
     )
     job_day2 = SetQualityAndNaNCalibrationJob(params_day2, work_folder2)
     _, datafile2 = job_day2.run_calibration(handler_day2, config)
@@ -185,6 +189,7 @@ def run_calibration_on_config_file(
     handler_day1 = CalibrationLayerPathHandler.from_method(
         method=CalibrationMethod.SET_QUALITY_AND_NAN,
         content_date=content_date,
+        settings=AppSettings(),
     )
     job_day1 = SetQualityAndNaNCalibrationJob(params_day1, work_folder)
     json_file, datafile1 = job_day1.run_calibration(handler_day1, config)

--- a/tests/integration/test_setQualityAndNan.py
+++ b/tests/integration/test_setQualityAndNan.py
@@ -52,8 +52,8 @@ def test_calibration_job_creates_quality_flag_layer_file_json_and_csv_with_corre
 
     config = SetQualityAndNaNConfig(csv_file=str(quality_csv))
 
-    cal_handler = CalibrationLayerPathHandler(
-        descriptor=CalibrationMethod.SET_QUALITY_AND_NAN.short_name,
+    cal_handler = CalibrationLayerPathHandler.from_method(
+        method=CalibrationMethod.SET_QUALITY_AND_NAN,
         content_date=datetime(2026, 1, 16),
     )
 
@@ -100,8 +100,8 @@ def test_run_calibration_writes_epoch_as_full_iso_datetime_when_clipped_to_day_b
     )
     work_folder = tmp_path / "work"
     work_folder.mkdir()
-    handler = CalibrationLayerPathHandler(
-        descriptor=CalibrationMethod.SET_QUALITY_AND_NAN.short_name,
+    handler = CalibrationLayerPathHandler.from_method(
+        method=CalibrationMethod.SET_QUALITY_AND_NAN,
         content_date=datetime(2026, 1, 16),
     )
     job = SetQualityAndNaNCalibrationJob(params, work_folder)
@@ -131,8 +131,8 @@ def test_calibration_job_splits_across_days(tmp_path):
     params_day1 = CalibrationJobParameters(
         date=datetime(2026, 1, 16), mode=ScienceMode.Normal, sensor=Sensor.MAGO
     )
-    handler_day1 = CalibrationLayerPathHandler(
-        descriptor=CalibrationMethod.SET_QUALITY_AND_NAN.short_name,
+    handler_day1 = CalibrationLayerPathHandler.from_method(
+        method=CalibrationMethod.SET_QUALITY_AND_NAN,
         content_date=datetime(2026, 1, 16),
     )
     job_day1 = SetQualityAndNaNCalibrationJob(params_day1, work_folder)
@@ -151,8 +151,8 @@ def test_calibration_job_splits_across_days(tmp_path):
     params_day2 = CalibrationJobParameters(
         date=datetime(2026, 1, 17), mode=ScienceMode.Normal, sensor=Sensor.MAGO
     )
-    handler_day2 = CalibrationLayerPathHandler(
-        descriptor=CalibrationMethod.SET_QUALITY_AND_NAN.short_name,
+    handler_day2 = CalibrationLayerPathHandler.from_method(
+        method=CalibrationMethod.SET_QUALITY_AND_NAN,
         content_date=datetime(2026, 1, 17),
     )
     job_day2 = SetQualityAndNaNCalibrationJob(params_day2, work_folder2)
@@ -182,8 +182,8 @@ def run_calibration_on_config_file(
     params_day1 = CalibrationJobParameters(
         date=content_date, mode=ScienceMode.Normal, sensor=Sensor.MAGO
     )
-    handler_day1 = CalibrationLayerPathHandler(
-        descriptor=CalibrationMethod.SET_QUALITY_AND_NAN.short_name,
+    handler_day1 = CalibrationLayerPathHandler.from_method(
+        method=CalibrationMethod.SET_QUALITY_AND_NAN,
         content_date=content_date,
     )
     job_day1 = SetQualityAndNaNCalibrationJob(params_day1, work_folder)

--- a/tests/unit/test_CalculatedOffsetsPathHandler.py
+++ b/tests/unit/test_CalculatedOffsetsPathHandler.py
@@ -3,6 +3,8 @@
 from datetime import datetime
 from pathlib import Path
 
+import pytest
+
 from imap_mag.io.file.CalculatedOffsetsPathHandler import (
     SPIN_OPTIMISED,
     SPIN_PLANE,
@@ -36,10 +38,18 @@ class TestCalculatedOffsetsPathHandler:
             == "calibration/calculated_offsets/spin_optimised"
         )
 
-    def test_filename(self):
+    def test_filename_spin_plane(self):
         assert (
-            _handler(sensor="magi", version=3).get_filename()
+            _handler(sensor="magi", offset_type=SPIN_PLANE, version=3).get_filename()
             == "imap_mag_magi-spin-plane-offsets_20260114_v003.csv"
+        )
+
+    def test_filename_spin_optimised(self):
+        assert (
+            _handler(
+                sensor="magi", offset_type=SPIN_OPTIMISED, version=3
+            ).get_filename()
+            == "imap_mag_magi-spin-plane-optimised-offsets_20260114_v003.csv"
         )
 
     def test_full_path(self):
@@ -48,11 +58,13 @@ class TestCalculatedOffsetsPathHandler:
             "imap_mag_mago-spin-plane-offsets_20260114_v024.csv"
         )
 
-    def test_filename_and_folder_identical_across_offset_types(self):
-        # Both folders hold identically-named files; only the folder differs.
+    def test_filename_is_unique_across_offset_types(self):
+        # The two products have distinct names as well as distinct folders.
         plane = _handler(offset_type=SPIN_PLANE)
         optimised = _handler(offset_type=SPIN_OPTIMISED)
-        assert plane.get_filename() == optimised.get_filename()
+        assert plane.get_filename() != optimised.get_filename()
+        assert "optimised" in optimised.get_filename()
+        assert "optimised" not in plane.get_filename()
         assert plane.get_folder_structure() != optimised.get_folder_structure()
 
     def test_supports_sequencing_and_bumps_version(self):
@@ -75,16 +87,25 @@ class TestCalculatedOffsetsPathHandler:
             pattern.search("imap_mag_mago-spin-plane-offsets_20260115_v024.csv") is None
         )
 
-    def test_from_filename_roundtrip(self):
+    def test_from_filename_roundtrip_spin_plane(self):
         handler = CalculatedOffsetsPathHandler.from_filename(
-            f"{SPIN_PLANE}/imap_mag_magi-spin-plane-offsets_20260114_v007.csv"
+            "calculated_offsets/spin_plane/imap_mag_magi-spin-plane-offsets_20260114_v007.csv"
         )
         assert handler is not None
         assert handler.sensor == "magi"
         assert handler.content_date == DATE
         assert handler.version == 7
-        # offset_type is unknowable from the name alone.
+        # The descriptor identifies the offset type.
         assert handler.offset_type == SPIN_PLANE
+
+    def test_from_filename_roundtrip_spin_optimised(self):
+        handler = CalculatedOffsetsPathHandler.from_filename(
+            "calculated_offsets/spin_optimised/imap_mag_mago-spin-plane-optimised-offsets_20260114_v007.csv"
+        )
+        assert handler is not None
+        assert handler.sensor == "mago"
+        assert handler.offset_type == SPIN_OPTIMISED
+        assert handler.version == 7
 
     def test_from_filename_rejects_unrelated_names(self):
         assert CalculatedOffsetsPathHandler.from_filename("something_else.csv") is None
@@ -95,11 +116,11 @@ class TestCalculatedOffsetsPathHandler:
             is None
         )
 
-    def test_from_filename_infers_offset_type_from_parent(self, tmp_path):
-        f: Path = (
+    def test_from_filename_file_optimised(self, tmp_path):
+        f = (
             tmp_path
             / SPIN_OPTIMISED
-            / "imap_mag_mago-spin-plane-offsets_20260114_v000.csv"
+            / "imap_mag_mago-spin-plane-optimised-offsets_20260114_v000.csv"
         )
         f.parent.mkdir(parents=True)
         f.write_text("data")
@@ -113,16 +134,27 @@ class TestCalculatedOffsetsPathHandler:
             "calibration/calculated_offsets/spin_optimised"
         )
 
-    def test_from_filename_rejects_bad_folder(self, tmp_path):
+    def test_from_filename_rejects_folder_name_mismatch(self, tmp_path):
+        # A spin_plane-named file sitting in the spin_optimised folder is rejected.
+        f = (
+            tmp_path
+            / SPIN_OPTIMISED
+            / "imap_mag_mago-spin-plane-offsets_20260114_v000.csv"
+        )
+        f.parent.mkdir(parents=True)
+        f.write_text("data")
+        with pytest.raises(ValueError, match="implies offset type"):
+            CalculatedOffsetsPathHandler.from_filename(f)
+
+    def test_from_filename_ignores_bad_folder(self, tmp_path):
         f = tmp_path / "wrong" / "imap_mag_mago-spin-plane-offsets_20260114_v000.csv"
         f.parent.mkdir(parents=True)
         f.write_text("data")
-        handler = CalculatedOffsetsPathHandler.from_filename(f)
-        assert handler is None
+        assert CalculatedOffsetsPathHandler.from_filename(f) is None
 
     def test_from_filename_rejects_bad_name(self, tmp_path):
         f = tmp_path / SPIN_PLANE / "not-an-offsets-file.csv"
         f.parent.mkdir(parents=True)
         f.write_text("data")
-        handler = CalculatedOffsetsPathHandler.from_filename(f)
-        assert handler is None
+
+        assert CalculatedOffsetsPathHandler.from_filename(f) is None

--- a/tests/unit/test_CalculatedOffsetsPathHandler.py
+++ b/tests/unit/test_CalculatedOffsetsPathHandler.py
@@ -1,0 +1,128 @@
+"""Tests for CalculatedOffsetsPathHandler."""
+
+from datetime import datetime
+from pathlib import Path
+
+from imap_mag.io.file.CalculatedOffsetsPathHandler import (
+    SPIN_OPTIMISED,
+    SPIN_PLANE,
+    CalculatedOffsetsPathHandler,
+)
+
+DATE = datetime(2026, 1, 14)
+
+
+def _handler(
+    sensor: str = "mago",
+    offset_type: str = SPIN_PLANE,
+    version: int = 24,
+) -> CalculatedOffsetsPathHandler:
+    return CalculatedOffsetsPathHandler(
+        sensor=sensor,
+        offset_type=offset_type,
+        content_date=DATE,
+        version=version,
+    )
+
+
+class TestCalculatedOffsetsPathHandler:
+    def test_folder_structure_per_offset_type(self):
+        assert (
+            _handler(offset_type=SPIN_PLANE).get_folder_structure()
+            == "calibration/calculated_offsets/spin_plane"
+        )
+        assert (
+            _handler(offset_type=SPIN_OPTIMISED).get_folder_structure()
+            == "calibration/calculated_offsets/spin_optimised"
+        )
+
+    def test_filename(self):
+        assert (
+            _handler(sensor="magi", version=3).get_filename()
+            == "imap_mag_magi-spin-plane-offsets_20260114_v003.csv"
+        )
+
+    def test_full_path(self):
+        assert _handler(version=24).get_full_path(Path("/store")) == Path(
+            "/store/calibration/calculated_offsets/spin_plane/"
+            "imap_mag_mago-spin-plane-offsets_20260114_v024.csv"
+        )
+
+    def test_filename_and_folder_identical_across_offset_types(self):
+        # Both folders hold identically-named files; only the folder differs.
+        plane = _handler(offset_type=SPIN_PLANE)
+        optimised = _handler(offset_type=SPIN_OPTIMISED)
+        assert plane.get_filename() == optimised.get_filename()
+        assert plane.get_folder_structure() != optimised.get_folder_structure()
+
+    def test_supports_sequencing_and_bumps_version(self):
+        handler = _handler(version=24)
+        assert handler.supports_sequencing() is True
+        handler.increase_sequence()
+        assert handler.version == 25
+        assert "_v025.csv" in handler.get_filename()
+
+    def test_unsequenced_pattern_matches_all_versions(self):
+        pattern = _handler().get_unsequenced_pattern()
+        m = pattern.search("imap_mag_mago-spin-plane-offsets_20260114_v024.csv")
+        assert m is not None
+        assert m.group("version") == "024"
+        # Different sensor / date must not match.
+        assert (
+            pattern.search("imap_mag_magi-spin-plane-offsets_20260114_v024.csv") is None
+        )
+        assert (
+            pattern.search("imap_mag_mago-spin-plane-offsets_20260115_v024.csv") is None
+        )
+
+    def test_from_filename_roundtrip(self):
+        handler = CalculatedOffsetsPathHandler.from_filename(
+            f"{SPIN_PLANE}/imap_mag_magi-spin-plane-offsets_20260114_v007.csv"
+        )
+        assert handler is not None
+        assert handler.sensor == "magi"
+        assert handler.content_date == DATE
+        assert handler.version == 7
+        # offset_type is unknowable from the name alone.
+        assert handler.offset_type == SPIN_PLANE
+
+    def test_from_filename_rejects_unrelated_names(self):
+        assert CalculatedOffsetsPathHandler.from_filename("something_else.csv") is None
+        assert (
+            CalculatedOffsetsPathHandler.from_filename(
+                "imap_mag_l2-norm-offsets_20260114_v001.cdf"
+            )
+            is None
+        )
+
+    def test_from_filename_infers_offset_type_from_parent(self, tmp_path):
+        f: Path = (
+            tmp_path
+            / SPIN_OPTIMISED
+            / "imap_mag_mago-spin-plane-offsets_20260114_v000.csv"
+        )
+        f.parent.mkdir(parents=True)
+        f.write_text("data")
+
+        handler = CalculatedOffsetsPathHandler.from_filename(f)
+        assert handler is not None
+        assert handler.offset_type == SPIN_OPTIMISED
+        assert handler.sensor == "mago"
+        assert handler.content_date == DATE
+        assert handler.get_folder_structure() == (
+            "calibration/calculated_offsets/spin_optimised"
+        )
+
+    def test_from_filename_rejects_bad_folder(self, tmp_path):
+        f = tmp_path / "wrong" / "imap_mag_mago-spin-plane-offsets_20260114_v000.csv"
+        f.parent.mkdir(parents=True)
+        f.write_text("data")
+        handler = CalculatedOffsetsPathHandler.from_filename(f)
+        assert handler is None
+
+    def test_from_filename_rejects_bad_name(self, tmp_path):
+        f = tmp_path / SPIN_PLANE / "not-an-offsets-file.csv"
+        f.parent.mkdir(parents=True)
+        f.write_text("data")
+        handler = CalculatedOffsetsPathHandler.from_filename(f)
+        assert handler is None

--- a/tests/unit/test_DatastoreFileManager.py
+++ b/tests/unit/test_DatastoreFileManager.py
@@ -378,6 +378,42 @@ def test_calibration_layer_csv_saved_at_matching_version(temp_folder_path):
     assert csv_result.read_bytes() == work_csv.read_bytes()
 
 
+def test_allow_overwrite_replaces_same_version(temp_folder_path):
+    """allow_overwrite=True writes new content at the exact requested version."""
+    date = datetime(2026, 1, 16)
+
+    store_dir = temp_folder_path / "calibration" / "layers" / "2026" / "01"
+    store_dir.mkdir(parents=True)
+    write_calibration_layer_pair(store_dir, "quality-norm", date, 3, seed=0)
+    existing_json = store_dir / "imap_mag_quality-norm-layer_20260116_v001.0003.json"
+    import hashlib
+
+    original_digest = hashlib.md5(existing_json.read_bytes()).hexdigest()
+
+    work_dir = temp_folder_path / "work"
+    work_dir.mkdir()
+    work_json, _ = write_calibration_layer_pair(
+        work_dir, "quality-norm", date, 3, seed=99
+    )
+
+    manager = _manager(temp_folder_path)
+    handler = CalibrationLayerPathHandler(
+        descriptor="quality-norm", content_date=date, version=3
+    )
+    handler.allow_overwrite = True
+
+    (result_path, _) = manager.add_file(work_json, handler)
+
+    assert result_path.name == "imap_mag_quality-norm-layer_20260116_v001.0003.json"
+    # Content replaced — hash differs because the seed (and thus timestamp+hash) changed.
+    new_digest = hashlib.md5(result_path.read_bytes()).hexdigest()
+    assert new_digest != original_digest
+    # No v001.0004 should have been created.
+    assert not (
+        store_dir / "imap_mag_quality-norm-layer_20260116_v001.0004.json"
+    ).exists()
+
+
 # ── Disk space threshold checks ───────────────────────────────────────────────
 
 

--- a/tests/unit/test_DatastoreFileManager.py
+++ b/tests/unit/test_DatastoreFileManager.py
@@ -304,7 +304,7 @@ def test_calibration_layer_identical_content_deduplicates_to_existing_version(
 
     manager = _manager(temp_folder_path)
     handler = CalibrationLayerPathHandler(
-        descriptor="quality-norm", content_date=date, version=1
+        descriptor="quality-norm", content_date=date, version=1, version_major=1
     )
 
     (result_path, _) = manager.add_file(work_json, handler)
@@ -336,7 +336,7 @@ def test_calibration_layer_different_content_bumps_to_v002(
 
     manager = _manager(temp_folder_path)
     handler = CalibrationLayerPathHandler(
-        descriptor="quality-norm", content_date=date, version=1
+        descriptor="quality-norm", content_date=date, version=1, version_major=1
     )
 
     (result_path, _) = manager.add_file(work_json, handler)
@@ -367,7 +367,7 @@ def test_calibration_layer_csv_saved_at_matching_version(temp_folder_path):
 
     manager = _manager(temp_folder_path)
     json_handler = CalibrationLayerPathHandler(
-        descriptor="quality-norm", content_date=date, version=1
+        descriptor="quality-norm", content_date=date, version=1, version_major=1
     )
     manager.add_file(work_json, json_handler)
 
@@ -398,9 +398,9 @@ def test_allow_overwrite_replaces_same_version(temp_folder_path):
 
     manager = _manager(temp_folder_path)
     handler = CalibrationLayerPathHandler(
-        descriptor="quality-norm", content_date=date, version=3
+        descriptor="quality-norm", content_date=date, version=3, version_major=1
     )
-    handler.allow_overwrite = True
+    handler.versioning_mode = handler.VersionMode.USER_OVERRIDE
 
     (result_path, _) = manager.add_file(work_json, handler)
 

--- a/tests/unit/test_apply.py
+++ b/tests/unit/test_apply.py
@@ -14,7 +14,7 @@ from imap_mag.cli.apply import (
     apply,
     cleanup_workfolder_after_apply,
 )
-from imap_mag.config import SaveMode
+from imap_mag.config import AppSettings, SaveMode
 from imap_mag.util import ReferenceFrame
 
 
@@ -344,6 +344,7 @@ class TestSetupZeroCalibrationLayer:
                 work_folder=work_folder,
                 workScienceFile=tmp_path / "science.cdf",
                 content_date=datetime(2025, 10, 17),
+                app_settings=AppSettings(),
             )
 
         mock_zero_layer.writeToFile.assert_called_once()
@@ -378,6 +379,7 @@ class TestSetupZeroCalibrationLayer:
                 work_folder=work_folder,
                 workScienceFile=tmp_path / "science.cdf",
                 content_date=datetime(2025, 10, 17),
+                app_settings=AppSettings(),
             )
 
         assert result == existing_file

--- a/tests/unit/test_calibrate_version_override.py
+++ b/tests/unit/test_calibrate_version_override.py
@@ -1,0 +1,128 @@
+"""Tests for the --version-number-override feature in the calibrate CLI.
+
+These tests verify that forcing a specific (major, minor) version:
+- Bypasses the normal auto-increment so the layer lands at the requested version.
+- Overwrites an existing layer at that version when the content differs.
+- Rejects invalid override values early via _validate_version_number_override.
+"""
+
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from imap_mag.cli.calibrate import _validate_version_number_override, calibrate
+from imap_mag.util import ScienceMode
+from mag_toolkit.calibration import CalibrationMethod, Sensor
+from tests.util.miscellaneous import write_calibration_layer_pair
+
+MODULE_CALL_MATLAB = (
+    "mag_toolkit.calibration.calibrators.GradiometerCalibration.call_matlab"
+)
+DATE = datetime(2026, 9, 30)
+
+
+def _cal_work_folder(base: Path, date: datetime, mode: str = "norm") -> Path:
+    return base / f"calibrate_{date.strftime('%Y%m%d')}_{mode}"
+
+
+# ── _validate_version_number_override ─────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "override,error_fragment",
+    [
+        ((True, 0), "bool"),
+        ((0, False), "bool"),
+        ((1.5, 0), "integer"),
+        ((0, 2.0), "integer"),
+        ((-1, 0), "non-negative"),
+        ((0, -1), "non-negative"),
+        ((1000, 0), "at most 999"),
+        ((0, 10000), "at most 9999"),
+    ],
+)
+def test_invalid_override_rejected(override, error_fragment):
+    with pytest.raises(ValueError, match=error_fragment):
+        _validate_version_number_override(override)
+
+
+def test_none_override_returns_none():
+    assert _validate_version_number_override(None) is None
+
+
+def test_valid_override_is_returned():
+    assert _validate_version_number_override((3, 42)) == (3, 42)
+
+
+# ── override at the calibrate() level ─────────────────────────────────────────
+
+
+def test_override_forces_version_no_upversion(
+    monkeypatch, temp_datastore, dynamic_work_folder
+):
+    """With a version override the layer is written at the forced version, not max+1."""
+    work = _cal_work_folder(dynamic_work_folder, DATE)
+
+    # Pre-populate v001 in the datastore so auto-increment would produce v002.
+    layers_dir = temp_datastore / "calibration/layers/2026/09"
+    layers_dir.mkdir(parents=True, exist_ok=True)
+    write_calibration_layer_pair(layers_dir, "gradiometer-norm", DATE, 1, seed=1)
+
+    def mock_call_matlab(command):
+        write_calibration_layer_pair(work, "gradiometer-norm", DATE, 1, seed=99)
+
+    monkeypatch.setattr(MODULE_CALL_MATLAB, mock_call_matlab)
+
+    calibrate(
+        start_date=DATE,
+        method=CalibrationMethod.GRADIOMETER,
+        mode=ScienceMode.Normal,
+        sensor=Sensor.MAGO,
+        configuration='{"kappa": 0.0, "sc_interference_threshold": 10.0}',
+        version_number_override=(1, 1),
+    )
+
+    # The override forces v001.0001; v001.0002 must not exist.
+    assert (
+        layers_dir / "imap_mag_gradiometer-norm-layer_20260930_v001.0001.json"
+    ).exists()
+    assert not (
+        layers_dir / "imap_mag_gradiometer-norm-layer_20260930_v001.0002.json"
+    ).exists()
+
+
+def test_override_overwrites_layer_content(
+    monkeypatch, temp_datastore, dynamic_work_folder
+):
+    """Content at the forced version is replaced when the new calibration differs."""
+    work = _cal_work_folder(dynamic_work_folder, DATE)
+
+    layers_dir = temp_datastore / "calibration/layers/2026/09"
+    layers_dir.mkdir(parents=True, exist_ok=True)
+
+    # Existing v001.0005 with seed=0
+    write_calibration_layer_pair(layers_dir, "gradiometer-norm", DATE, 5, seed=0)
+    existing_json = (
+        layers_dir / "imap_mag_gradiometer-norm-layer_20260930_v001.0005.json"
+    )
+    original_mtime = existing_json.stat().st_mtime
+
+    def mock_call_matlab(command):
+        # The override seeds the handler at v005; Gradiometer expects that filename.
+        write_calibration_layer_pair(work, "gradiometer-norm", DATE, 5, seed=42)
+
+    monkeypatch.setattr(MODULE_CALL_MATLAB, mock_call_matlab)
+
+    calibrate(
+        start_date=DATE,
+        method=CalibrationMethod.GRADIOMETER,
+        mode=ScienceMode.Normal,
+        sensor=Sensor.MAGO,
+        configuration='{"kappa": 0.0, "sc_interference_threshold": 10.0}',
+        version_number_override=(1, 5),
+    )
+
+    # v005 exists and its content has been replaced (mtime changed).
+    assert existing_json.exists()
+    assert existing_json.stat().st_mtime != original_mtime

--- a/tests/unit/test_calibration_multi_file.py
+++ b/tests/unit/test_calibration_multi_file.py
@@ -15,6 +15,9 @@ from imap_mag.io.FilePathHandlerSelector import NoProviderFoundError
 from imap_mag.util import ScienceMode
 from mag_toolkit.calibration import CalibrationMethod
 from mag_toolkit.calibration.CalibrationConfig import ScriptedL2CalibrationConfig
+from mag_toolkit.calibration.calibrators.ScriptedL2Calibration import (
+    OUTPUT_SUBFOLDER_NAME,
+)
 from tests.util.miscellaneous import write_calibration_layer_pair
 
 MODULE_CALL_MATLAB = (
@@ -42,7 +45,7 @@ def test_saves_all_returned_files(
     work_folder = dynamic_work_folder / "calibrate_20260130_norm"
 
     def mock_call_matlab(command, **kwargs):
-        outputs = work_folder / "outputs"
+        outputs = work_folder / OUTPUT_SUBFOLDER_NAME
         write_calibration_layer_pair(outputs, "manual-norm", DATE, 1)
 
     monkeypatch.setattr(MODULE_CALL_MATLAB, mock_call_matlab)
@@ -109,7 +112,7 @@ def test_unhandled_file_raises(
     work_folder = dynamic_work_folder / "calibrate_20260130_norm"
 
     def mock_call_matlab(command, **kwargs):
-        outputs = work_folder / "outputs"
+        outputs = work_folder / OUTPUT_SUBFOLDER_NAME
         # Write only an unrecognised file type (no JSON/CSV pair)
         (outputs / "unknown_output.xyz").write_bytes(b"data")
 

--- a/tests/unit/test_calibration_multi_file.py
+++ b/tests/unit/test_calibration_multi_file.py
@@ -1,0 +1,131 @@
+"""Tests for the multi-file save loop in calibrate._calibrate_for_date.
+
+These tests exercise the logic that collects every file returned by a
+CalibrationJob, resolves a path handler for each one, and publishes them
+all — including extra products beyond the standard JSON+CSV pair.
+"""
+
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from imap_mag.cli.calibrate import calibrate
+from imap_mag.io.FilePathHandlerSelector import NoProviderFoundError
+from imap_mag.util import ScienceMode
+from mag_toolkit.calibration import CalibrationMethod
+from mag_toolkit.calibration.CalibrationConfig import ScriptedL2CalibrationConfig
+from tests.util.miscellaneous import write_calibration_layer_pair
+
+MODULE_CALL_MATLAB = (
+    "mag_toolkit.calibration.calibrators.ScriptedL2Calibration.call_matlab"
+)
+DATE = datetime(2026, 1, 30)
+
+
+def _make_matlab_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    script = repo / "+calibration" / "+scripts" / "calibrate_l2_offsets.m"
+    script.parent.mkdir(parents=True)
+    script.write_text("function calibrate_l2_offsets(); end")
+    return repo
+
+
+def test_saves_all_returned_files(
+    monkeypatch, temp_datastore, dynamic_work_folder, tmp_path
+):
+    """Extra files beyond the JSON+CSV pair are published to the datastore."""
+    repo = _make_matlab_repo(tmp_path)
+    (temp_datastore / "spice" / "mk").mkdir(parents=True, exist_ok=True)
+    (temp_datastore / "spice" / "mk" / "mk.txt").write_text("kernel")
+
+    work_folder = dynamic_work_folder / "calibrate_20260130_norm"
+
+    def mock_call_matlab(command, **kwargs):
+        outputs = work_folder / "outputs"
+        write_calibration_layer_pair(outputs, "manual-norm", DATE, 1)
+
+    monkeypatch.setattr(MODULE_CALL_MATLAB, mock_call_matlab)
+
+    config = ScriptedL2CalibrationConfig(
+        calibration_matrix_version=8,
+        input_json_file="input.json",
+        matlab_repo=str(repo),
+    )
+
+    results = calibrate(
+        start_date=DATE,
+        method=CalibrationMethod.SCRIPTED_L2_CALIBRATION,
+        mode=ScienceMode.Normal,
+        configuration=config.model_dump_json(),
+        metakernel=Path("mk.txt"),
+    )
+
+    assert len(results) == 1
+    layers_dir = temp_datastore / "calibration/layers/2026/01"
+    assert (layers_dir / "imap_mag_manual-norm-layer_20260130_v001.0001.json").exists()
+    assert (
+        layers_dir / "imap_mag_manual-norm-layer-data_20260130_v001.0001.csv"
+    ).exists()
+
+
+def test_zero_returned_files_raises(
+    monkeypatch, temp_datastore, dynamic_work_folder, tmp_path
+):
+    """Calibration that returns no files raises ValueError before any publishing."""
+    repo = _make_matlab_repo(tmp_path)
+    (temp_datastore / "spice" / "mk").mkdir(parents=True, exist_ok=True)
+    (temp_datastore / "spice" / "mk" / "mk.txt").write_text("kernel")
+
+    def mock_call_matlab(command, **kwargs):
+        pass  # writes nothing to the outputs folder
+
+    monkeypatch.setattr(MODULE_CALL_MATLAB, mock_call_matlab)
+
+    config = ScriptedL2CalibrationConfig(
+        calibration_matrix_version=8,
+        input_json_file="input.json",
+        matlab_repo=str(repo),
+    )
+
+    with pytest.raises(FileNotFoundError, match="produced no output files"):
+        calibrate(
+            start_date=DATE,
+            method=CalibrationMethod.SCRIPTED_L2_CALIBRATION,
+            mode=ScienceMode.Normal,
+            configuration=config.model_dump_json(),
+            metakernel=Path("mk.txt"),
+        )
+
+
+def test_unhandled_file_raises(
+    monkeypatch, temp_datastore, dynamic_work_folder, tmp_path
+):
+    """A file type that no handler recognises raises NoProviderFoundError."""
+    repo = _make_matlab_repo(tmp_path)
+    (temp_datastore / "spice" / "mk").mkdir(parents=True, exist_ok=True)
+    (temp_datastore / "spice" / "mk" / "mk.txt").write_text("kernel")
+
+    work_folder = dynamic_work_folder / "calibrate_20260130_norm"
+
+    def mock_call_matlab(command, **kwargs):
+        outputs = work_folder / "outputs"
+        # Write only an unrecognised file type (no JSON/CSV pair)
+        (outputs / "unknown_output.xyz").write_bytes(b"data")
+
+    monkeypatch.setattr(MODULE_CALL_MATLAB, mock_call_matlab)
+
+    config = ScriptedL2CalibrationConfig(
+        calibration_matrix_version=8,
+        input_json_file="input.json",
+        matlab_repo=str(repo),
+    )
+
+    with pytest.raises(NoProviderFoundError):
+        calibrate(
+            start_date=DATE,
+            method=CalibrationMethod.SCRIPTED_L2_CALIBRATION,
+            mode=ScienceMode.Normal,
+            configuration=config.model_dump_json(),
+            metakernel=Path("mk.txt"),
+        )

--- a/tests/unit/test_calibration_without_matlab.py
+++ b/tests/unit/test_calibration_without_matlab.py
@@ -11,6 +11,33 @@ from tests.util.miscellaneous import (
 )
 
 
+def test_gradiometry_returns_list(
+    monkeypatch,
+    temp_datastore,
+    dynamic_work_folder,
+):
+    """gradiometry() returns a list of Path objects (not a single Path or tuple)."""
+
+    def mock_call_matlab(command):
+        write_calibration_layer_pair(
+            _cal_work_folder(dynamic_work_folder, datetime(2026, 9, 30)),
+            "gradiometer-norm",
+            datetime(2026, 9, 30),
+            1,
+        )
+
+    monkeypatch.setattr(
+        "mag_toolkit.calibration.calibrators.GradiometerCalibration.call_matlab",
+        mock_call_matlab,
+    )
+
+    result = gradiometry(start_date=datetime(2026, 9, 30))
+
+    assert isinstance(result, list)
+    assert len(result) >= 1
+    assert all(isinstance(p, Path) for p in result)
+
+
 def _cal_work_folder(base: Path, date: datetime, mode: str = "norm") -> Path:
     """The calibrate command's dynamic work folder (base/calibrate_{date}_{mode})."""
     return base / f"calibrate_{date.strftime('%Y%m%d')}_{mode}"

--- a/tests/unit/test_pathHandlers.py
+++ b/tests/unit/test_pathHandlers.py
@@ -166,7 +166,7 @@ def test_calibration_layer_get_equivalent_data_handler():
                 version=2,
                 descriptor="offsets",
                 content_date=datetime(2025, 10, 4),
-                has_major_version=False,
+                _has_major_version=False,
             ),
             "CalibrationLayerPathHandler",
         ),
@@ -517,7 +517,7 @@ def test_science_get_unsequenced_pattern_matches_both_formats():
         ),
         (
             "imap_mag_noop-layer_20250101_v003.json",
-            1,
+            0,
             3,
             False,
         ),
@@ -533,7 +533,7 @@ def test_calibration_layer_from_filename_parses_version_fields(
     assert handler is not None
     assert handler.version_major == expected_version_major
     assert handler.version == expected_version
-    assert handler.has_major_version == expected_has_major_version
+    assert handler._has_major_version == expected_has_major_version
 
 
 def test_calibration_layer_get_filename_with_major_version_produces_new_format():
@@ -543,7 +543,7 @@ def test_calibration_layer_get_filename_with_major_version_produces_new_format()
         content_date=datetime(2025, 1, 1),
         version=5,
         version_major=1,
-        has_major_version=True,
+        _has_major_version=True,
     )
 
     # Exercise and verify.
@@ -557,7 +557,7 @@ def test_calibration_layer_get_filename_without_major_version_produces_legacy_fo
         content_date=datetime(2025, 1, 1),
         version=3,
         version_major=1,
-        has_major_version=False,
+        _has_major_version=False,
     )
 
     # Exercise and verify.

--- a/tests/unit/test_scripted_l2_calibration.py
+++ b/tests/unit/test_scripted_l2_calibration.py
@@ -89,7 +89,7 @@ def _make_job(
 
 def _handler(version: int) -> CalibrationLayerPathHandler:
     return CalibrationLayerPathHandler(
-        descriptor="manual-norm", content_date=DATE, version=version
+        descriptor="manual-norm", content_date=DATE, version=version, version_major=1
     )
 
 
@@ -507,7 +507,7 @@ def test_run_calibration_passes_override_version(tmp_path, monkeypatch):
         content_date=DATE,
         version_major=2,
         version=5,
-        has_major_version=True,
+        _has_major_version=True,
     )
     job.run_calibration(handler, config)
 

--- a/tests/unit/test_scripted_l2_calibration.py
+++ b/tests/unit/test_scripted_l2_calibration.py
@@ -24,7 +24,7 @@ from mag_toolkit.calibration.CalibrationConfig import (
     ScriptedL2CalibrationConfig,
 )
 from mag_toolkit.calibration.calibrators.ScriptedL2Calibration import (
-    OUTPUT_SUBFOLDER_NAME,
+    OFFSETS_FOLDER_NAME,
     SPARSE_DATASTORE_FOLDER_NAME,
     USER_CONFIG_FILENAME,
     ScriptedL2CalibrationJob,
@@ -89,8 +89,32 @@ def _make_job(
 
 def _handler(version: int) -> CalibrationLayerPathHandler:
     return CalibrationLayerPathHandler(
-        descriptor="manual-norm", content_date=DATE, version=version, version_major=1
+        descriptor="manual-norm", content_date=DATE, version=version
     )
+
+
+def _write_work_offsets(
+    work_folder: Path, date: datetime = DATE, tag: str = "a"
+) -> None:
+    """Simulate MATLAB writing the four spin-plane offset CSVs into the work folder.
+
+    One CSV per sensor (mago/magi) per offset type (spin_plane/spin_optimised);
+    the per-type file name is derived from the path handler so it matches production.
+    Content is tagged so tests can force identical vs changed content.
+    """
+    from imap_mag.io.file import CalculatedOffsetsPathHandler
+    from imap_mag.io.file.CalculatedOffsetsPathHandler import OFFSET_TYPES
+
+    for offset_type in OFFSET_TYPES:
+        folder = work_folder / OFFSETS_FOLDER_NAME / offset_type
+        folder.mkdir(parents=True, exist_ok=True)
+        for sensor in ("mago", "magi"):
+            handler = CalculatedOffsetsPathHandler(
+                sensor=sensor, offset_type=offset_type, content_date=date, version=0
+            )
+            (folder / handler.get_filename()).write_text(
+                f"offsets,{sensor},{offset_type},{tag}\n"
+            )
 
 
 def test_requires_matlab_repo_path(tmp_path):
@@ -153,36 +177,42 @@ def test_run_calibration_builds_command_and_collects_output(tmp_path, monkeypatc
         captured["command"] = command
         captured["kwargs"] = kwargs
         assert (work_folder / USER_CONFIG_FILENAME).exists()
-        write_calibration_layer_pair(
-            work_folder / OUTPUT_SUBFOLDER_NAME, "manual-norm", DATE, 7
-        )
+        write_calibration_layer_pair(work_folder, "manual-norm", DATE, 7)
 
     monkeypatch.setattr(MODULE_CALL_MATLAB, mock_call_matlab)
 
-    returned = job.run_calibration(_handler(7), config)
+    metadata_path, data_path = job.run_calibration(_handler(7), config)
     job.cleanup()
 
-    output_dir = work_folder / OUTPUT_SUBFOLDER_NAME
-    assert len(returned) == 2
     assert (
-        output_dir / "imap_mag_manual-norm-layer_20260130_v001.0007.json"
-    ) in returned
+        metadata_path
+        == work_folder / "imap_mag_manual-norm-layer_20260130_v001.0007.json"
+    )
     assert (
-        output_dir / "imap_mag_manual-norm-layer-data_20260130_v001.0007.csv"
-    ) in returned
-    for p in returned:
-        assert p.exists()
+        data_path
+        == work_folder / "imap_mag_manual-norm-layer-data_20260130_v001.0007.csv"
+    )
+    assert metadata_path.exists() and data_path.exists()
 
     command = captured["command"]
     assert command.startswith("calibration.scripts.calibrate_l2_offsets(")
     assert "datetime(2026,1,30), datetime(2026,1,30)" in command
     assert ", 8, " in command
     assert '"metakernel.txt"' in command
-    assert ", [1, 7], " in command
+    assert ", 7, " in command
     assert '"+calibration/calibration/input_v002.json"' in command
     assert 'modes=["norm"]' in command
     assert "publish_to_sharepoint=false" in command
     assert "display_plots=false" in command
+    # imap-pipeline-core dictates the versioned layer/data file names to MATLAB.
+    assert (
+        'output_layer_filename="imap_mag_manual-norm-layer_20260130_v001.0007.json"'
+        in command
+    )
+    assert (
+        'output_data_filename="imap_mag_manual-norm-layer-data_20260130_v001.0007.csv"'
+        in command
+    )
 
     # Invoked from the repo root, no project path preamble.
     assert captured["kwargs"]["cwd"] == job.matlab_repo_path
@@ -215,9 +245,7 @@ def test_burst_mode_uses_burst_timeout(tmp_path, monkeypatch):
 
     def mock_call_matlab(command, **kwargs):
         captured["kwargs"] = kwargs
-        write_calibration_layer_pair(
-            job.work_folder / OUTPUT_SUBFOLDER_NAME, "manual-burst", DATE, 1
-        )
+        write_calibration_layer_pair(job.work_folder, "manual-burst", DATE, 1)
 
     monkeypatch.setattr(MODULE_CALL_MATLAB, mock_call_matlab)
     job.run_calibration(
@@ -246,22 +274,19 @@ def test_user_config_maps_datastore_and_work_folder(tmp_path, monkeypatch):
         captured_config.update(
             json.loads((work_folder / USER_CONFIG_FILENAME).read_text())
         )
-        write_calibration_layer_pair(
-            work_folder / OUTPUT_SUBFOLDER_NAME, "manual-norm", DATE, 1
-        )
+        write_calibration_layer_pair(work_folder, "manual-norm", DATE, 1)
 
     monkeypatch.setattr(MODULE_CALL_MATLAB, mock_call_matlab)
     job.run_calibration(_handler(1), config)
 
-    output_dir = work_folder / OUTPUT_SUBFOLDER_NAME
     assert captured_config["sharepoint_flight_data"] == str(datastore.resolve())
     assert captured_config["spice_metakernal_root"] == str(datastore.resolve())
-    assert captured_config["l2_pre_calibration_outputs"] == str(output_dir.resolve())
+    assert captured_config["l2_pre_calibration_outputs"] == str(work_folder.resolve())
     assert (
         captured_config["report_folder"]
         == str(datastore.resolve()) + "/calibration/reports"
     )
-    assert captured_config["output_layers_folder"] == str(output_dir.resolve())
+    assert captured_config["output_layers_folder"] == str(work_folder.resolve())
 
 
 def test_local_work_folder_copy_builds_sparse_datastore(tmp_path, monkeypatch):
@@ -293,9 +318,7 @@ def test_local_work_folder_copy_builds_sparse_datastore(tmp_path, monkeypatch):
         captured["kernel_copied"] = (
             sparse_root / "spice" / "lsk" / "naif0012.tls"
         ).exists()
-        write_calibration_layer_pair(
-            work_folder / OUTPUT_SUBFOLDER_NAME, "manual-norm", DATE, 1
-        )
+        write_calibration_layer_pair(work_folder, "manual-norm", DATE, 1)
 
     monkeypatch.setattr(MODULE_CALL_MATLAB, mock_call_matlab)
     job.run_calibration(_handler(1), config)
@@ -331,7 +354,7 @@ def test_missing_output_layer_raises(tmp_path, monkeypatch):
         matlab_repo=str(job.matlab_repo_path),
     )
     monkeypatch.setattr(MODULE_CALL_MATLAB, lambda *a, **k: None)
-    with pytest.raises(FileNotFoundError, match="produced no output files"):
+    with pytest.raises(FileNotFoundError, match="was not created"):
         job.run_calibration(_handler(1), config)
 
 
@@ -365,9 +388,7 @@ def test_generates_metakernel_when_none(tmp_path, monkeypatch):
 
     def mock_call_matlab(command, **kwargs):
         captured["command"] = command
-        write_calibration_layer_pair(
-            work_folder / OUTPUT_SUBFOLDER_NAME, "manual-norm", DATE, 1
-        )
+        write_calibration_layer_pair(work_folder, "manual-norm", DATE, 1)
 
     monkeypatch.setattr(MODULE_CALL_MATLAB, mock_call_matlab)
     job.run_calibration(_handler(1), config)
@@ -425,7 +446,7 @@ def test_scripted_calibrate_cli_publishes_layer(
 
     def mock_call_matlab(command, **kwargs):
         assert "calibrate_l2_offsets" in command
-        write_calibration_layer_pair(work_folder / "outputs", "manual-norm", DATE, 1)
+        write_calibration_layer_pair(work_folder, "manual-norm", DATE, 1)
 
     monkeypatch.setattr(MODULE_CALL_MATLAB, mock_call_matlab)
 
@@ -454,39 +475,52 @@ def test_scripted_calibrate_cli_publishes_layer(
     ).exists()
 
 
-def test_run_calibration_returns_all_produced_files(tmp_path, monkeypatch):
-    """All files MATLAB writes to the output subfolder are returned as a list."""
+def test_write_offsets_threads_flag_config_and_collects_files(tmp_path, monkeypatch):
+    """With write_offsets set: MATLAB gets the flag + folder, and CSVs are collected."""
     job = _make_job(tmp_path)
+    work_folder = job.work_folder
     config = ScriptedL2CalibrationConfig(
         calibration_matrix_version=8,
         input_json_file="input.json",
-        datastore_access_mode=DatastoreAccessMode.READ_DIRECTLY,
         matlab_repo=str(job.matlab_repo_path),
+        write_offsets=True,
     )
 
+    captured = {}
+
     def mock_call_matlab(command, **kwargs):
-        output_dir = job.work_folder / OUTPUT_SUBFOLDER_NAME
-        write_calibration_layer_pair(output_dir, "manual-norm", DATE, 1)
-        (output_dir / "extra_report.pdf").write_bytes(b"report data")
+        captured["command"] = command
+        captured["config"] = json.loads(
+            (work_folder / USER_CONFIG_FILENAME).read_text()
+        )
+        # The offsets sub-folders must already exist for MATLAB to write into.
+        assert (work_folder / OFFSETS_FOLDER_NAME / "spin_plane").is_dir()
+        assert (work_folder / OFFSETS_FOLDER_NAME / "spin_optimised").is_dir()
+        write_calibration_layer_pair(work_folder, "manual-norm", DATE, 1)
+        _write_work_offsets(work_folder)
 
     monkeypatch.setattr(MODULE_CALL_MATLAB, mock_call_matlab)
+    job.run_calibration(_handler(1), config)
 
-    returned = job.run_calibration(_handler(1), config)
+    assert "write_offsets=true" in captured["command"]
+    assert captured["config"]["output_offsets_folder"] == str(
+        (work_folder / OFFSETS_FOLDER_NAME).resolve()
+    )
+    # Four offsets collected: mago/magi x spin_plane/spin_optimised.
+    assert len(job.written_offset_files) == 4
+    assert {f.parent.name for f in job.written_offset_files} == {
+        "spin_plane",
+        "spin_optimised",
+    }
 
-    assert len(returned) == 3
-    assert any(p.suffix == ".json" for p in returned)
-    assert any(p.suffix == ".csv" for p in returned)
-    assert any(p.name == "extra_report.pdf" for p in returned)
-    assert all(p.exists() for p in returned)
 
-
-def test_run_calibration_passes_override_version(tmp_path, monkeypatch):
-    """output_version in the MATLAB command reflects the handler's major and minor version."""
+def test_write_offsets_defaults_off(tmp_path, monkeypatch):
+    """Without the flag, MATLAB is told write_offsets=false and nothing is collected."""
     job = _make_job(tmp_path)
+    work_folder = job.work_folder
     config = ScriptedL2CalibrationConfig(
         calibration_matrix_version=8,
         input_json_file="input.json",
-        datastore_access_mode=DatastoreAccessMode.READ_DIRECTLY,
         matlab_repo=str(job.matlab_repo_path),
     )
 
@@ -494,19 +528,106 @@ def test_run_calibration_passes_override_version(tmp_path, monkeypatch):
 
     def mock_call_matlab(command, **kwargs):
         captured["command"] = command
-        write_calibration_layer_pair(
-            job.work_folder / OUTPUT_SUBFOLDER_NAME, "manual-norm", DATE, 5
-        )
+        write_calibration_layer_pair(work_folder, "manual-norm", DATE, 1)
+
+    monkeypatch.setattr(MODULE_CALL_MATLAB, mock_call_matlab)
+    job.run_calibration(_handler(1), config)
+
+    assert "write_offsets=false" in captured["command"]
+    assert job.written_offset_files == []
+
+
+def _run_scripted_cli_with_offsets(monkeypatch, work_folder: Path, tag: str) -> None:
+    """Run the calibrate() CLI for the scripted-L2 method with offsets enabled."""
+
+    def mock_call_matlab(command, **kwargs):
+        write_calibration_layer_pair(work_folder, "manual-norm", DATE, 1)
+        _write_work_offsets(work_folder, tag=tag)
 
     monkeypatch.setattr(MODULE_CALL_MATLAB, mock_call_matlab)
 
-    handler = CalibrationLayerPathHandler(
-        descriptor="manual-norm",
-        content_date=DATE,
-        version_major=2,
-        version=5,
-        _has_major_version=True,
+    repo = _make_matlab_repo(work_folder.parent / f"repo_{tag}")
+    config = ScriptedL2CalibrationConfig(
+        calibration_matrix_version=8,
+        input_json_file="+calibration/calibration/input_v002.json",
+        matlab_repo=str(repo),
+        write_offsets=True,
     )
-    job.run_calibration(handler, config)
+    calibrate(
+        start_date=DATE,
+        method=CalibrationMethod.SCRIPTED_L2_CALIBRATION,
+        mode=ScienceMode.Normal,
+        configuration=config.model_dump_json(),
+        metakernel=Path("metakernel.txt"),
+    )
 
-    assert ", [2, 5]," in captured["command"]
+
+def _offsets_path(datastore: Path, offset_type: str, sensor: str, version: int) -> Path:
+    from imap_mag.io.file import CalculatedOffsetsPathHandler
+
+    handler = CalculatedOffsetsPathHandler(
+        sensor=sensor, offset_type=offset_type, content_date=DATE, version=version
+    )
+    return handler.get_full_path(datastore)
+
+
+def test_scripted_calibrate_cli_publishes_offsets(
+    monkeypatch, temp_datastore, dynamic_work_folder, tmp_path
+):
+    """First run publishes the four offset CSVs at v001 in the datastore."""
+    work_folder = dynamic_work_folder / "calibrate_20260130_norm"
+    _run_scripted_cli_with_offsets(monkeypatch, work_folder, tag="a")
+
+    for offset_type in ("spin_plane", "spin_optimised"):
+        for sensor in ("mago", "magi"):
+            assert _offsets_path(temp_datastore, offset_type, sensor, 1).exists()
+
+    # Pin the exact (unique) file names for each product.
+    base = temp_datastore / "calibration/calculated_offsets"
+    assert (
+        base / "spin_plane/imap_mag_mago-spin-plane-offsets_20260130_v001.csv"
+    ).exists()
+    assert (
+        base
+        / "spin_optimised/imap_mag_mago-spin-plane-optimised-offsets_20260130_v001.csv"
+    ).exists()
+
+
+def test_scripted_calibrate_cli_upversions_changed_offsets(
+    monkeypatch, temp_datastore, dynamic_work_folder, tmp_path
+):
+    """Different content vs the latest datastore offsets is written as a new version."""
+    # Seed the datastore with a v001 that differs from what the run will produce.
+    for offset_type in ("spin_plane", "spin_optimised"):
+        for sensor in ("mago", "magi"):
+            existing = _offsets_path(temp_datastore, offset_type, sensor, 1)
+            existing.parent.mkdir(parents=True, exist_ok=True)
+            existing.write_text("pre-existing different content\n")
+
+    work_folder = dynamic_work_folder / "calibrate_20260130_norm"
+    _run_scripted_cli_with_offsets(monkeypatch, work_folder, tag="new")
+
+    for offset_type in ("spin_plane", "spin_optimised"):
+        for sensor in ("mago", "magi"):
+            assert _offsets_path(temp_datastore, offset_type, sensor, 1).exists()
+            assert _offsets_path(temp_datastore, offset_type, sensor, 2).exists()
+
+
+def test_scripted_calibrate_cli_reuses_identical_offsets(
+    monkeypatch, temp_datastore, dynamic_work_folder, tmp_path
+):
+    """Identical content to the latest datastore offsets does not create a new version."""
+    # Seed the datastore v001 with byte-identical content to what the run produces.
+    for offset_type in ("spin_plane", "spin_optimised"):
+        for sensor in ("mago", "magi"):
+            existing = _offsets_path(temp_datastore, offset_type, sensor, 1)
+            existing.parent.mkdir(parents=True, exist_ok=True)
+            existing.write_text(f"offsets,{sensor},{offset_type},same\n")
+
+    work_folder = dynamic_work_folder / "calibrate_20260130_norm"
+    _run_scripted_cli_with_offsets(monkeypatch, work_folder, tag="same")
+
+    for offset_type in ("spin_plane", "spin_optimised"):
+        for sensor in ("mago", "magi"):
+            assert _offsets_path(temp_datastore, offset_type, sensor, 1).exists()
+            assert not _offsets_path(temp_datastore, offset_type, sensor, 2).exists()

--- a/tests/unit/test_scripted_l2_calibration.py
+++ b/tests/unit/test_scripted_l2_calibration.py
@@ -11,7 +11,8 @@ import pytest
 
 from imap_mag.cli.calibrate import calibrate
 from imap_mag.config import AppSettings, GradiometryConfig
-from imap_mag.io.file import CalibrationLayerPathHandler
+from imap_mag.io.file import CalculatedOffsetsPathHandler, CalibrationLayerPathHandler
+from imap_mag.io.file.CalculatedOffsetsPathHandler import OFFSET_TYPES
 from imap_mag.io.file.IFilePathHandler import IFilePathHandler
 from imap_mag.util import ScienceMode
 from mag_toolkit.calibration import (
@@ -23,6 +24,7 @@ from mag_toolkit.calibration import (
 from mag_toolkit.calibration.CalibrationConfig import (
     ScriptedL2CalibrationConfig,
 )
+from mag_toolkit.calibration.CalibrationLayer import CalibrationLayer
 from mag_toolkit.calibration.calibrators.ScriptedL2Calibration import (
     OUTPUT_SUBFOLDER_NAME,
     SPARSE_DATASTORE_FOLDER_NAME,
@@ -103,9 +105,6 @@ def _write_work_offsets(
     the per-type file name is derived from the path handler so it matches production.
     Content is tagged so tests can force identical vs changed content.
     """
-    from imap_mag.io.file import CalculatedOffsetsPathHandler
-    from imap_mag.io.file.CalculatedOffsetsPathHandler import OFFSET_TYPES
-
     for offset_type in OFFSET_TYPES:
         folder = output_dir / offset_type
         folder.mkdir(parents=True, exist_ok=True)
@@ -425,8 +424,6 @@ def test_python_preserves_matlab_supplied_data_hash(tmp_path):
     in the pipeline (``save_calibration_layer``) must keep MATLAB's value rather than
     overwrite it from the CSV on disk.
     """
-    from mag_toolkit.calibration.CalibrationLayer import CalibrationLayer
-
     json_path, _ = write_calibration_layer_pair(tmp_path, "manual-norm", DATE, 1)
     matlab_hash = "deadbeefdeadbeefdeadbeefdeadbeef"
     layer = CalibrationLayer.from_file(json_path, load_contents=False)
@@ -477,10 +474,7 @@ def test_scripted_calibrate_cli_publishes_layer(
     ).exists()
 
 
-def test_write_offsets_threads_flag_config_and_collects_files(tmp_path, monkeypatch):
-    """MATLAB writes offsets into the output dir and they are returned alongside layer files."""
-    from imap_mag.io.file.CalculatedOffsetsPathHandler import OFFSET_TYPES
-
+def test_run_calibration_collects_files_in_offset_directories(tmp_path, monkeypatch):
     job = _make_job(tmp_path)
     work_folder = job.work_folder
     config = ScriptedL2CalibrationConfig(
@@ -510,6 +504,15 @@ def test_write_offsets_threads_flag_config_and_collects_files(tmp_path, monkeypa
     assert {f.parent.name for f in items if f.parent.name in OFFSET_TYPES} == set(
         OFFSET_TYPES
     )
+    expected = {
+        "outputs/imap_mag_manual-norm-layer-data_20260130_v001.0001.csv",
+        "outputs/imap_mag_manual-norm-layer_20260130_v001.0001.json",
+        "outputs/spin_optimised/imap_mag_magi-spin-plane-optimised-offsets_20260130_v001.csv",
+        "outputs/spin_optimised/imap_mag_mago-spin-plane-optimised-offsets_20260130_v001.csv",
+        "outputs/spin_plane/imap_mag_magi-spin-plane-offsets_20260130_v001.csv",
+        "outputs/spin_plane/imap_mag_mago-spin-plane-offsets_20260130_v001.csv",
+    }
+    assert {str(f.relative_to(work_folder)) for f in items} == expected
 
 
 def _run_scripted_cli_with_offsets(monkeypatch, work_folder: Path, tag: str) -> None:
@@ -538,8 +541,6 @@ def _run_scripted_cli_with_offsets(monkeypatch, work_folder: Path, tag: str) -> 
 
 
 def _offsets_path(datastore: Path, offset_type: str, sensor: str, version: int) -> Path:
-    from imap_mag.io.file import CalculatedOffsetsPathHandler
-
     handler = CalculatedOffsetsPathHandler(
         sensor=sensor, offset_type=offset_type, content_date=DATE, version=version
     )

--- a/tests/unit/test_scripted_l2_calibration.py
+++ b/tests/unit/test_scripted_l2_calibration.py
@@ -24,7 +24,7 @@ from mag_toolkit.calibration.CalibrationConfig import (
     ScriptedL2CalibrationConfig,
 )
 from mag_toolkit.calibration.calibrators.ScriptedL2Calibration import (
-    OFFSETS_FOLDER_NAME,
+    OUTPUT_SUBFOLDER_NAME,
     SPARSE_DATASTORE_FOLDER_NAME,
     USER_CONFIG_FILENAME,
     ScriptedL2CalibrationJob,
@@ -94,10 +94,11 @@ def _handler(version: int) -> CalibrationLayerPathHandler:
 
 
 def _write_work_offsets(
-    work_folder: Path, date: datetime = DATE, tag: str = "a"
+    output_dir: Path, date: datetime = DATE, tag: str = "a"
 ) -> None:
-    """Simulate MATLAB writing the four spin-plane offset CSVs into the work folder.
+    """Simulate MATLAB writing the four spin-plane offset CSVs into the output dir.
 
+    MATLAB writes offsets directly under ``output_dir/<offset_type>/``.
     One CSV per sensor (mago/magi) per offset type (spin_plane/spin_optimised);
     the per-type file name is derived from the path handler so it matches production.
     Content is tagged so tests can force identical vs changed content.
@@ -106,11 +107,11 @@ def _write_work_offsets(
     from imap_mag.io.file.CalculatedOffsetsPathHandler import OFFSET_TYPES
 
     for offset_type in OFFSET_TYPES:
-        folder = work_folder / OFFSETS_FOLDER_NAME / offset_type
+        folder = output_dir / offset_type
         folder.mkdir(parents=True, exist_ok=True)
         for sensor in ("mago", "magi"):
             handler = CalculatedOffsetsPathHandler(
-                sensor=sensor, offset_type=offset_type, content_date=date, version=0
+                sensor=sensor, offset_type=offset_type, content_date=date, version=1
             )
             (folder / handler.get_filename()).write_text(
                 f"offsets,{sensor},{offset_type},{tag}\n"
@@ -177,42 +178,32 @@ def test_run_calibration_builds_command_and_collects_output(tmp_path, monkeypatc
         captured["command"] = command
         captured["kwargs"] = kwargs
         assert (work_folder / USER_CONFIG_FILENAME).exists()
-        write_calibration_layer_pair(work_folder, "manual-norm", DATE, 7)
+        write_calibration_layer_pair(
+            work_folder / OUTPUT_SUBFOLDER_NAME, "manual-norm", DATE, 7
+        )
 
     monkeypatch.setattr(MODULE_CALL_MATLAB, mock_call_matlab)
 
-    metadata_path, data_path = job.run_calibration(_handler(7), config)
+    returned = job.run_calibration(_handler(7), config)
+    output_dir = work_folder / OUTPUT_SUBFOLDER_NAME
+    json_file = output_dir / "imap_mag_manual-norm-layer_20260130_v001.0007.json"
+    csv_file = output_dir / "imap_mag_manual-norm-layer-data_20260130_v001.0007.csv"
     job.cleanup()
 
-    assert (
-        metadata_path
-        == work_folder / "imap_mag_manual-norm-layer_20260130_v001.0007.json"
-    )
-    assert (
-        data_path
-        == work_folder / "imap_mag_manual-norm-layer-data_20260130_v001.0007.csv"
-    )
-    assert metadata_path.exists() and data_path.exists()
+    assert json_file in returned
+    assert csv_file in returned
+    assert json_file.exists() and csv_file.exists()
 
     command = captured["command"]
     assert command.startswith("calibration.scripts.calibrate_l2_offsets(")
     assert "datetime(2026,1,30), datetime(2026,1,30)" in command
     assert ", 8, " in command
     assert '"metakernel.txt"' in command
-    assert ", 7, " in command
+    assert "[0, 7]" in command
     assert '"+calibration/calibration/input_v002.json"' in command
     assert 'modes=["norm"]' in command
     assert "publish_to_sharepoint=false" in command
     assert "display_plots=false" in command
-    # imap-pipeline-core dictates the versioned layer/data file names to MATLAB.
-    assert (
-        'output_layer_filename="imap_mag_manual-norm-layer_20260130_v001.0007.json"'
-        in command
-    )
-    assert (
-        'output_data_filename="imap_mag_manual-norm-layer-data_20260130_v001.0007.csv"'
-        in command
-    )
 
     # Invoked from the repo root, no project path preamble.
     assert captured["kwargs"]["cwd"] == job.matlab_repo_path
@@ -245,7 +236,9 @@ def test_burst_mode_uses_burst_timeout(tmp_path, monkeypatch):
 
     def mock_call_matlab(command, **kwargs):
         captured["kwargs"] = kwargs
-        write_calibration_layer_pair(job.work_folder, "manual-burst", DATE, 1)
+        write_calibration_layer_pair(
+            job.work_folder / OUTPUT_SUBFOLDER_NAME, "manual-burst", DATE, 1
+        )
 
     monkeypatch.setattr(MODULE_CALL_MATLAB, mock_call_matlab)
     job.run_calibration(
@@ -274,19 +267,22 @@ def test_user_config_maps_datastore_and_work_folder(tmp_path, monkeypatch):
         captured_config.update(
             json.loads((work_folder / USER_CONFIG_FILENAME).read_text())
         )
-        write_calibration_layer_pair(work_folder, "manual-norm", DATE, 1)
+        write_calibration_layer_pair(
+            work_folder / OUTPUT_SUBFOLDER_NAME, "manual-norm", DATE, 1
+        )
 
     monkeypatch.setattr(MODULE_CALL_MATLAB, mock_call_matlab)
     job.run_calibration(_handler(1), config)
 
+    output_dir = work_folder / OUTPUT_SUBFOLDER_NAME
     assert captured_config["sharepoint_flight_data"] == str(datastore.resolve())
     assert captured_config["spice_metakernal_root"] == str(datastore.resolve())
-    assert captured_config["l2_pre_calibration_outputs"] == str(work_folder.resolve())
+    assert captured_config["l2_pre_calibration_outputs"] == str(output_dir.resolve())
     assert (
         captured_config["report_folder"]
         == str(datastore.resolve()) + "/calibration/reports"
     )
-    assert captured_config["output_layers_folder"] == str(work_folder.resolve())
+    assert captured_config["output_layers_folder"] == str(output_dir.resolve())
 
 
 def test_local_work_folder_copy_builds_sparse_datastore(tmp_path, monkeypatch):
@@ -318,7 +314,9 @@ def test_local_work_folder_copy_builds_sparse_datastore(tmp_path, monkeypatch):
         captured["kernel_copied"] = (
             sparse_root / "spice" / "lsk" / "naif0012.tls"
         ).exists()
-        write_calibration_layer_pair(work_folder, "manual-norm", DATE, 1)
+        write_calibration_layer_pair(
+            work_folder / OUTPUT_SUBFOLDER_NAME, "manual-norm", DATE, 1
+        )
 
     monkeypatch.setattr(MODULE_CALL_MATLAB, mock_call_matlab)
     job.run_calibration(_handler(1), config)
@@ -354,7 +352,7 @@ def test_missing_output_layer_raises(tmp_path, monkeypatch):
         matlab_repo=str(job.matlab_repo_path),
     )
     monkeypatch.setattr(MODULE_CALL_MATLAB, lambda *a, **k: None)
-    with pytest.raises(FileNotFoundError, match="was not created"):
+    with pytest.raises(FileNotFoundError, match="no output files"):
         job.run_calibration(_handler(1), config)
 
 
@@ -388,7 +386,9 @@ def test_generates_metakernel_when_none(tmp_path, monkeypatch):
 
     def mock_call_matlab(command, **kwargs):
         captured["command"] = command
-        write_calibration_layer_pair(work_folder, "manual-norm", DATE, 1)
+        write_calibration_layer_pair(
+            work_folder / OUTPUT_SUBFOLDER_NAME, "manual-norm", DATE, 1
+        )
 
     monkeypatch.setattr(MODULE_CALL_MATLAB, mock_call_matlab)
     job.run_calibration(_handler(1), config)
@@ -446,7 +446,9 @@ def test_scripted_calibrate_cli_publishes_layer(
 
     def mock_call_matlab(command, **kwargs):
         assert "calibrate_l2_offsets" in command
-        write_calibration_layer_pair(work_folder, "manual-norm", DATE, 1)
+        write_calibration_layer_pair(
+            work_folder / OUTPUT_SUBFOLDER_NAME, "manual-norm", DATE, 1
+        )
 
     monkeypatch.setattr(MODULE_CALL_MATLAB, mock_call_matlab)
 
@@ -476,14 +478,15 @@ def test_scripted_calibrate_cli_publishes_layer(
 
 
 def test_write_offsets_threads_flag_config_and_collects_files(tmp_path, monkeypatch):
-    """With write_offsets set: MATLAB gets the flag + folder, and CSVs are collected."""
+    """MATLAB writes offsets into the output dir and they are returned alongside layer files."""
+    from imap_mag.io.file.CalculatedOffsetsPathHandler import OFFSET_TYPES
+
     job = _make_job(tmp_path)
     work_folder = job.work_folder
     config = ScriptedL2CalibrationConfig(
         calibration_matrix_version=8,
         input_json_file="input.json",
         matlab_repo=str(job.matlab_repo_path),
-        write_offsets=True,
     )
 
     captured = {}
@@ -493,56 +496,29 @@ def test_write_offsets_threads_flag_config_and_collects_files(tmp_path, monkeypa
         captured["config"] = json.loads(
             (work_folder / USER_CONFIG_FILENAME).read_text()
         )
-        # The offsets sub-folders must already exist for MATLAB to write into.
-        assert (work_folder / OFFSETS_FOLDER_NAME / "spin_plane").is_dir()
-        assert (work_folder / OFFSETS_FOLDER_NAME / "spin_optimised").is_dir()
-        write_calibration_layer_pair(work_folder, "manual-norm", DATE, 1)
-        _write_work_offsets(work_folder)
+        output_dir = work_folder / OUTPUT_SUBFOLDER_NAME
+        write_calibration_layer_pair(output_dir, "manual-norm", DATE, 1)
+        _write_work_offsets(output_dir)
 
     monkeypatch.setattr(MODULE_CALL_MATLAB, mock_call_matlab)
-    job.run_calibration(_handler(1), config)
+    items = job.run_calibration(_handler(1), config)
 
-    assert "write_offsets=true" in captured["command"]
-    assert captured["config"]["output_offsets_folder"] == str(
-        (work_folder / OFFSETS_FOLDER_NAME).resolve()
+    output_dir = work_folder / OUTPUT_SUBFOLDER_NAME
+    assert captured["config"]["output_offsets_folder"] == str(output_dir.resolve())
+    # Six files total: layer JSON + CSV + 4 offsets (mago/magi x spin_plane/spin_optimised).
+    assert len(items) == 6
+    assert {f.parent.name for f in items if f.parent.name in OFFSET_TYPES} == set(
+        OFFSET_TYPES
     )
-    # Four offsets collected: mago/magi x spin_plane/spin_optimised.
-    assert len(job.written_offset_files) == 4
-    assert {f.parent.name for f in job.written_offset_files} == {
-        "spin_plane",
-        "spin_optimised",
-    }
-
-
-def test_write_offsets_defaults_off(tmp_path, monkeypatch):
-    """Without the flag, MATLAB is told write_offsets=false and nothing is collected."""
-    job = _make_job(tmp_path)
-    work_folder = job.work_folder
-    config = ScriptedL2CalibrationConfig(
-        calibration_matrix_version=8,
-        input_json_file="input.json",
-        matlab_repo=str(job.matlab_repo_path),
-    )
-
-    captured = {}
-
-    def mock_call_matlab(command, **kwargs):
-        captured["command"] = command
-        write_calibration_layer_pair(work_folder, "manual-norm", DATE, 1)
-
-    monkeypatch.setattr(MODULE_CALL_MATLAB, mock_call_matlab)
-    job.run_calibration(_handler(1), config)
-
-    assert "write_offsets=false" in captured["command"]
-    assert job.written_offset_files == []
 
 
 def _run_scripted_cli_with_offsets(monkeypatch, work_folder: Path, tag: str) -> None:
     """Run the calibrate() CLI for the scripted-L2 method with offsets enabled."""
 
     def mock_call_matlab(command, **kwargs):
-        write_calibration_layer_pair(work_folder, "manual-norm", DATE, 1)
-        _write_work_offsets(work_folder, tag=tag)
+        output_dir = work_folder / OUTPUT_SUBFOLDER_NAME
+        write_calibration_layer_pair(output_dir, "manual-norm", DATE, 1)
+        _write_work_offsets(output_dir, tag=tag)
 
     monkeypatch.setattr(MODULE_CALL_MATLAB, mock_call_matlab)
 
@@ -551,7 +527,6 @@ def _run_scripted_cli_with_offsets(monkeypatch, work_folder: Path, tag: str) -> 
         calibration_matrix_version=8,
         input_json_file="+calibration/calibration/input_v002.json",
         matlab_repo=str(repo),
-        write_offsets=True,
     )
     calibrate(
         start_date=DATE,

--- a/tests/unit/test_scripted_l2_calibration.py
+++ b/tests/unit/test_scripted_l2_calibration.py
@@ -178,13 +178,11 @@ def test_run_calibration_builds_command_and_collects_output(tmp_path, monkeypatc
     assert "datetime(2026,1,30), datetime(2026,1,30)" in command
     assert ", 8, " in command
     assert '"metakernel.txt"' in command
-    assert ", 7, " in command
+    assert ", [1, 7], " in command
     assert '"+calibration/calibration/input_v002.json"' in command
     assert 'modes=["norm"]' in command
     assert "publish_to_sharepoint=false" in command
     assert "display_plots=false" in command
-    # MATLAB owns filename construction via the output_version keyword arg.
-    assert "output_version=[1 7]" in command
 
     # Invoked from the repo root, no project path preamble.
     assert captured["kwargs"]["cwd"] == job.matlab_repo_path
@@ -511,4 +509,4 @@ def test_run_calibration_passes_override_version(tmp_path, monkeypatch):
     )
     job.run_calibration(handler, config)
 
-    assert "output_version=[2 5]" in captured["command"]
+    assert ", [2, 5]," in captured["command"]

--- a/tests/unit/test_scripted_l2_calibration.py
+++ b/tests/unit/test_scripted_l2_calibration.py
@@ -24,6 +24,7 @@ from mag_toolkit.calibration.CalibrationConfig import (
     ScriptedL2CalibrationConfig,
 )
 from mag_toolkit.calibration.calibrators.ScriptedL2Calibration import (
+    OUTPUT_SUBFOLDER_NAME,
     SPARSE_DATASTORE_FOLDER_NAME,
     USER_CONFIG_FILENAME,
     ScriptedL2CalibrationJob,
@@ -152,22 +153,25 @@ def test_run_calibration_builds_command_and_collects_output(tmp_path, monkeypatc
         captured["command"] = command
         captured["kwargs"] = kwargs
         assert (work_folder / USER_CONFIG_FILENAME).exists()
-        write_calibration_layer_pair(work_folder, "manual-norm", DATE, 7)
+        write_calibration_layer_pair(
+            work_folder / OUTPUT_SUBFOLDER_NAME, "manual-norm", DATE, 7
+        )
 
     monkeypatch.setattr(MODULE_CALL_MATLAB, mock_call_matlab)
 
-    metadata_path, data_path = job.run_calibration(_handler(7), config)
+    returned = job.run_calibration(_handler(7), config)
     job.cleanup()
 
+    output_dir = work_folder / OUTPUT_SUBFOLDER_NAME
+    assert len(returned) == 2
     assert (
-        metadata_path
-        == work_folder / "imap_mag_manual-norm-layer_20260130_v001.0007.json"
-    )
+        output_dir / "imap_mag_manual-norm-layer_20260130_v001.0007.json"
+    ) in returned
     assert (
-        data_path
-        == work_folder / "imap_mag_manual-norm-layer-data_20260130_v001.0007.csv"
-    )
-    assert metadata_path.exists() and data_path.exists()
+        output_dir / "imap_mag_manual-norm-layer-data_20260130_v001.0007.csv"
+    ) in returned
+    for p in returned:
+        assert p.exists()
 
     command = captured["command"]
     assert command.startswith("calibration.scripts.calibrate_l2_offsets(")
@@ -179,15 +183,8 @@ def test_run_calibration_builds_command_and_collects_output(tmp_path, monkeypatc
     assert 'modes=["norm"]' in command
     assert "publish_to_sharepoint=false" in command
     assert "display_plots=false" in command
-    # imap-pipeline-core dictates the versioned layer/data file names to MATLAB.
-    assert (
-        'output_layer_filename="imap_mag_manual-norm-layer_20260130_v001.0007.json"'
-        in command
-    )
-    assert (
-        'output_data_filename="imap_mag_manual-norm-layer-data_20260130_v001.0007.csv"'
-        in command
-    )
+    # MATLAB owns filename construction via the output_version keyword arg.
+    assert "output_version=[1 7]" in command
 
     # Invoked from the repo root, no project path preamble.
     assert captured["kwargs"]["cwd"] == job.matlab_repo_path
@@ -220,7 +217,9 @@ def test_burst_mode_uses_burst_timeout(tmp_path, monkeypatch):
 
     def mock_call_matlab(command, **kwargs):
         captured["kwargs"] = kwargs
-        write_calibration_layer_pair(job.work_folder, "manual-burst", DATE, 1)
+        write_calibration_layer_pair(
+            job.work_folder / OUTPUT_SUBFOLDER_NAME, "manual-burst", DATE, 1
+        )
 
     monkeypatch.setattr(MODULE_CALL_MATLAB, mock_call_matlab)
     job.run_calibration(
@@ -249,19 +248,22 @@ def test_user_config_maps_datastore_and_work_folder(tmp_path, monkeypatch):
         captured_config.update(
             json.loads((work_folder / USER_CONFIG_FILENAME).read_text())
         )
-        write_calibration_layer_pair(work_folder, "manual-norm", DATE, 1)
+        write_calibration_layer_pair(
+            work_folder / OUTPUT_SUBFOLDER_NAME, "manual-norm", DATE, 1
+        )
 
     monkeypatch.setattr(MODULE_CALL_MATLAB, mock_call_matlab)
     job.run_calibration(_handler(1), config)
 
+    output_dir = work_folder / OUTPUT_SUBFOLDER_NAME
     assert captured_config["sharepoint_flight_data"] == str(datastore.resolve())
     assert captured_config["spice_metakernal_root"] == str(datastore.resolve())
-    assert captured_config["l2_pre_calibration_outputs"] == str(work_folder.resolve())
+    assert captured_config["l2_pre_calibration_outputs"] == str(output_dir.resolve())
     assert (
         captured_config["report_folder"]
         == str(datastore.resolve()) + "/calibration/reports"
     )
-    assert captured_config["output_layers_folder"] == str(work_folder.resolve())
+    assert captured_config["output_layers_folder"] == str(output_dir.resolve())
 
 
 def test_local_work_folder_copy_builds_sparse_datastore(tmp_path, monkeypatch):
@@ -293,7 +295,9 @@ def test_local_work_folder_copy_builds_sparse_datastore(tmp_path, monkeypatch):
         captured["kernel_copied"] = (
             sparse_root / "spice" / "lsk" / "naif0012.tls"
         ).exists()
-        write_calibration_layer_pair(work_folder, "manual-norm", DATE, 1)
+        write_calibration_layer_pair(
+            work_folder / OUTPUT_SUBFOLDER_NAME, "manual-norm", DATE, 1
+        )
 
     monkeypatch.setattr(MODULE_CALL_MATLAB, mock_call_matlab)
     job.run_calibration(_handler(1), config)
@@ -329,7 +333,7 @@ def test_missing_output_layer_raises(tmp_path, monkeypatch):
         matlab_repo=str(job.matlab_repo_path),
     )
     monkeypatch.setattr(MODULE_CALL_MATLAB, lambda *a, **k: None)
-    with pytest.raises(FileNotFoundError, match="was not created"):
+    with pytest.raises(FileNotFoundError, match="produced no output files"):
         job.run_calibration(_handler(1), config)
 
 
@@ -363,7 +367,9 @@ def test_generates_metakernel_when_none(tmp_path, monkeypatch):
 
     def mock_call_matlab(command, **kwargs):
         captured["command"] = command
-        write_calibration_layer_pair(work_folder, "manual-norm", DATE, 1)
+        write_calibration_layer_pair(
+            work_folder / OUTPUT_SUBFOLDER_NAME, "manual-norm", DATE, 1
+        )
 
     monkeypatch.setattr(MODULE_CALL_MATLAB, mock_call_matlab)
     job.run_calibration(_handler(1), config)
@@ -421,7 +427,7 @@ def test_scripted_calibrate_cli_publishes_layer(
 
     def mock_call_matlab(command, **kwargs):
         assert "calibrate_l2_offsets" in command
-        write_calibration_layer_pair(work_folder, "manual-norm", DATE, 1)
+        write_calibration_layer_pair(work_folder / "outputs", "manual-norm", DATE, 1)
 
     monkeypatch.setattr(MODULE_CALL_MATLAB, mock_call_matlab)
 
@@ -448,3 +454,61 @@ def test_scripted_calibrate_cli_publishes_layer(
         temp_datastore
         / "calibration/layers/2026/01/imap_mag_manual-norm-layer-data_20260130_v001.0001.csv"
     ).exists()
+
+
+def test_run_calibration_returns_all_produced_files(tmp_path, monkeypatch):
+    """All files MATLAB writes to the output subfolder are returned as a list."""
+    job = _make_job(tmp_path)
+    config = ScriptedL2CalibrationConfig(
+        calibration_matrix_version=8,
+        input_json_file="input.json",
+        datastore_access_mode=DatastoreAccessMode.READ_DIRECTLY,
+        matlab_repo=str(job.matlab_repo_path),
+    )
+
+    def mock_call_matlab(command, **kwargs):
+        output_dir = job.work_folder / OUTPUT_SUBFOLDER_NAME
+        write_calibration_layer_pair(output_dir, "manual-norm", DATE, 1)
+        (output_dir / "extra_report.pdf").write_bytes(b"report data")
+
+    monkeypatch.setattr(MODULE_CALL_MATLAB, mock_call_matlab)
+
+    returned = job.run_calibration(_handler(1), config)
+
+    assert len(returned) == 3
+    assert any(p.suffix == ".json" for p in returned)
+    assert any(p.suffix == ".csv" for p in returned)
+    assert any(p.name == "extra_report.pdf" for p in returned)
+    assert all(p.exists() for p in returned)
+
+
+def test_run_calibration_passes_override_version(tmp_path, monkeypatch):
+    """output_version in the MATLAB command reflects the handler's major and minor version."""
+    job = _make_job(tmp_path)
+    config = ScriptedL2CalibrationConfig(
+        calibration_matrix_version=8,
+        input_json_file="input.json",
+        datastore_access_mode=DatastoreAccessMode.READ_DIRECTLY,
+        matlab_repo=str(job.matlab_repo_path),
+    )
+
+    captured = {}
+
+    def mock_call_matlab(command, **kwargs):
+        captured["command"] = command
+        write_calibration_layer_pair(
+            job.work_folder / OUTPUT_SUBFOLDER_NAME, "manual-norm", DATE, 5
+        )
+
+    monkeypatch.setattr(MODULE_CALL_MATLAB, mock_call_matlab)
+
+    handler = CalibrationLayerPathHandler(
+        descriptor="manual-norm",
+        content_date=DATE,
+        version_major=2,
+        version=5,
+        has_major_version=True,
+    )
+    job.run_calibration(handler, config)
+
+    assert "output_version=[2 5]" in captured["command"]

--- a/tests/util/miscellaneous.py
+++ b/tests/util/miscellaneous.py
@@ -122,6 +122,7 @@ def write_calibration_layer_pair(
         validity=Validity(start=epoch, end=epoch),
         sensor=Sensor.MAGO,
         version=version,
+        version_major=1,
         metadata=CalibrationMetadata(
             dependencies=[],
             science=[],
@@ -134,7 +135,7 @@ def write_calibration_layer_pair(
     layer._contents = contents
 
     handler = CalibrationLayerPathHandler(
-        descriptor=descriptor, content_date=date, version=version
+        descriptor=descriptor, content_date=date, version=version, version_major=1
     )
     json_path = folder / handler.get_filename()
     layer.writeToFile(json_path)


### PR DESCRIPTION
## Summary

- **Multi-file output loop**: `CalibrationJob.run_calibration` now returns `Sequence[Path]` instead of a fixed `tuple[Path, Path]`. The save loop in `calibrate._calibrate_for_date` iterates over every returned path and resolves a handler via `FilePathHandlerSelector.find_by_path()`, publishing all files MATLAB writes — not just the standard JSON+CSV pair.
- **`output_version` passed to MATLAB**: `ScriptedL2Calibration` appends `output_version=[major minor]` to the MATLAB command so MATLAB owns filename construction. Python collects whatever files appear in the dedicated `outputs/` subfolder after the run.
- **`--version-number-override MAJOR MINOR` CLI option**: Forces a specific `(major, minor)` version instead of auto-incrementing. `_validate_version_number_override` rejects bools, non-integers, negatives, and out-of-range values. When set, `allow_overwrite=True` is propagated through `VersionedPathHandler`, `CalibrationLayerPathHandler`, `DatastoreFileManager`, and `DBIndexedDatastoreFileManager` so the existing file at that version is replaced in-place. The override is also forwarded through the Prefect flows in `performCalibration.py`.
- **Version bump**: `pyproject.toml` → `6.3.0`.

## Changes

### Source
- `src/mag_toolkit/calibration/calibrators/CalibrationJob.py` — return type `tuple[Path, Path]` → `Sequence[Path]`
- `src/mag_toolkit/calibration/calibrators/ScriptedL2Calibration.py` — `OUTPUT_SUBFOLDER_NAME`, stale-output prevention, `output_version` in MATLAB command, explicit `output_dir` param on `_write_user_config`
- `src/imap_mag/cli/calibrate.py` — `_validate_version_number_override`, multi-file save loop, `version_number_override` parameter
- `src/imap_mag/io/file/VersionedPathHandler.py` — `allow_overwrite: bool = False`
- `src/imap_mag/io/file/CalibrationLayerPathHandler.py` — `get_equivalent_data_handler()` copies `allow_overwrite`
- `src/imap_mag/io/DatastoreFileManager.py` — `allow_overwrite` branch in version selection
- `src/imap_mag/io/DBIndexedDatastoreFileManager.py` — `allow_overwrite` branch soft-deletes conflicting DB record before insert
- `src/prefect_server/performCalibration.py` — `version_number_override` forwarded in both flows

### Tests
- `tests/unit/test_calibrate_version_override.py` *(new)* — validation unit tests + end-to-end override tests
- `tests/unit/test_calibration_multi_file.py` *(new)* — extra files saved, zero files raises, unknown type raises
- `tests/unit/test_scripted_l2_calibration.py` — updated for `outputs/` subfolder, list return type, `output_version` in command
- `tests/unit/test_DatastoreFileManager.py` — `test_allow_overwrite_replaces_same_version` added
- `tests/unit/test_calibration_without_matlab.py` — `test_gradiometry_returns_list` added

---
_Generated by [Claude Code](https://claude.ai/code/session_01DyoiMch8Y1LpYXABhHWFKg)_