### PR TITLE
Pass $ref block reference instead of serialised block in split_by_day runs

### DIFF
--- a/src/prefect_server/performCalibration.py
+++ b/src/prefect_server/performCalibration.py
@@ -141,6 +141,40 @@ def _load_matlab_repo_block(
     return None
 
 
+def _configuration_for_deployment(
+    configuration: "PrefectScriptedL2CalibrationConfig | SetQualityAndNaNConfig | GradiometryConfig",
+) -> "dict | SetQualityAndNaNConfig | GradiometryConfig":
+    """Prepare configuration for passing to ``run_deployment``.
+
+    For ``PrefectScriptedL2CalibrationConfig``, any block stored in ``matlab_repo``
+    is replaced with a ``{"$ref": {"block_document_id": "..."}}`` reference so that
+    the child flow run re-loads the block from the block store (including its
+    credentials) rather than receiving a plain-dict serialisation that drops them.
+
+    Non-``PrefectScriptedL2CalibrationConfig`` configurations are returned unchanged.
+
+    Args:
+        configuration: The calibration configuration to prepare.
+
+    Returns:
+        A deployment-safe representation of the configuration.
+    """
+    if not isinstance(configuration, PrefectScriptedL2CalibrationConfig):
+        return configuration
+
+    matlab_repo = configuration.matlab_repo
+    if isinstance(matlab_repo, (GitHubRepository, LocalFileSystem)):
+        block_doc_id = getattr(matlab_repo, "_block_document_id", None)
+        if block_doc_id:
+            config_dict = configuration.model_dump()
+            config_dict["matlab_repo"] = {
+                "$ref": {"block_document_id": str(block_doc_id)}
+            }
+            return config_dict
+
+    return configuration
+
+
 def _resolve_matlab_repo_path(
     matlab_repo: "LocalFileSystem | GitHubRepository | str | None",
     work_folder: Path,
@@ -320,7 +354,7 @@ def calibrate_flow(
             deployment_name=f"{PREFECT_CONSTANTS.FLOW_NAMES.CALIBRATE}/{PREFECT_CONSTANTS.DEPLOYMENT_NAMES.CALIBRATE}",
             days=days,
             base_parameters={
-                "configuration": configuration,
+                "configuration": _configuration_for_deployment(configuration),
                 "mode": mode,
                 "sensor": sensor,
                 "save_mode": save_mode,
@@ -368,7 +402,7 @@ def calibrate_and_apply_flow(
             deployment_name=f"{PREFECT_CONSTANTS.FLOW_NAMES.CALIBRATE_AND_APPLY}/{PREFECT_CONSTANTS.DEPLOYMENT_NAMES.CALIBRATE_AND_APPLY}",
             days=days,
             base_parameters={
-                "configuration": configuration,
+                "configuration": _configuration_for_deployment(configuration),
                 "mode": mode,
                 "sensor": sensor,
                 "offset_file_output_type": offset_file_output_type,

--- a/tests/unit/test_performCalibration.py
+++ b/tests/unit/test_performCalibration.py
@@ -13,6 +13,7 @@ from mag_toolkit.calibration.CalibrationConfig import GradiometryConfig
 from prefect_server.constants import PREFECT_CONSTANTS
 from prefect_server.performCalibration import (
     PrefectScriptedL2CalibrationConfig,
+    _configuration_for_deployment,
     _days_in_range,
     _github_repo_name,
     _load_matlab_repo_block,
@@ -435,6 +436,167 @@ class TestSplitByDay:
 
         mock_run_deployment.assert_not_called()
         mock_apply.assert_called_once()
+
+
+class TestConfigurationForDeployment:
+    """_configuration_for_deployment replaces block objects with $ref references."""
+
+    def test_non_scripted_config_returned_unchanged(self):
+        config = GradiometryConfig()
+        assert _configuration_for_deployment(config) is config
+
+    def test_scripted_config_without_block_returned_unchanged(self):
+        config = PrefectScriptedL2CalibrationConfig(
+            calibration_matrix_version=8,
+            input_json_file="input.json",
+            matlab_repo="my-block-name",
+        )
+        result = _configuration_for_deployment(config)
+        assert result is config
+
+    def test_scripted_config_with_block_but_no_doc_id_returned_unchanged(self):
+        block = GitHubRepository(
+            repository_url="git@github.com:example-org/example-repo.git"
+        )
+        config = PrefectScriptedL2CalibrationConfig(
+            calibration_matrix_version=8,
+            input_json_file="input.json",
+            matlab_repo=block,
+        )
+        result = _configuration_for_deployment(config)
+        assert result is config
+
+    def test_github_block_with_doc_id_replaced_by_ref(self):
+        block = GitHubRepository(
+            repository_url="git@github.com:example-org/example-repo.git"
+        )
+        block._block_document_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        config = PrefectScriptedL2CalibrationConfig(
+            calibration_matrix_version=8,
+            input_json_file="input.json",
+            matlab_repo=block,
+        )
+
+        result = _configuration_for_deployment(config)
+
+        assert isinstance(result, dict)
+        assert result["matlab_repo"] == {
+            "$ref": {"block_document_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"}
+        }
+
+    def test_local_filesystem_block_with_doc_id_replaced_by_ref(self, tmp_path):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        block = LocalFileSystem(basepath=str(repo))
+        block._block_document_id = "11111111-2222-3333-4444-555555555555"
+        config = PrefectScriptedL2CalibrationConfig(
+            calibration_matrix_version=8,
+            input_json_file="input.json",
+            matlab_repo=block,
+        )
+
+        result = _configuration_for_deployment(config)
+
+        assert isinstance(result, dict)
+        assert result["matlab_repo"] == {
+            "$ref": {"block_document_id": "11111111-2222-3333-4444-555555555555"}
+        }
+
+    def test_ref_dict_contains_other_config_fields(self):
+        block = GitHubRepository(
+            repository_url="git@github.com:example-org/example-repo.git"
+        )
+        block._block_document_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        config = PrefectScriptedL2CalibrationConfig(
+            calibration_matrix_version=7,
+            input_json_file="my-input.json",
+            matlab_repo=block,
+        )
+
+        result = _configuration_for_deployment(config)
+
+        assert isinstance(result, dict)
+        assert result["calibration_matrix_version"] == 7
+        assert result["input_json_file"] == "my-input.json"
+
+
+class TestSplitByDayWithGithubBlock:
+    """split_by_day passes $ref block references, not serialised block objects."""
+
+    def _make_flow_run(self, name):
+        fake = MagicMock()
+        fake.name = name
+        return fake
+
+    def test_calibrate_flow_passes_ref_for_github_block(self):
+        block = GitHubRepository(
+            repository_url="git@github.com:example-org/example-repo.git"
+        )
+        block._block_document_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        config = PrefectScriptedL2CalibrationConfig(
+            calibration_matrix_version=9,
+            input_json_file="input.json",
+            matlab_repo=block,
+        )
+
+        with (
+            patch(
+                "prefect_server.performCalibration.run_deployment",
+                return_value=self._make_flow_run("child"),
+            ) as mock_run_deployment,
+            patch("prefect_server.performCalibration.calibrate"),
+        ):
+            calibrate_flow.fn(
+                start_date=datetime(2025, 1, 1),
+                end_date=datetime(2025, 1, 2),
+                configuration=config,
+                split_by_day=True,
+            )
+
+        assert mock_run_deployment.call_count == 2
+        for call in mock_run_deployment.call_args_list:
+            configuration_param = call.kwargs["parameters"]["configuration"]
+            assert isinstance(configuration_param, dict), (
+                "configuration must be a dict (not a Pydantic model) so Prefect "
+                "can resolve the $ref block reference in the child run"
+            )
+            assert configuration_param["matlab_repo"] == {
+                "$ref": {"block_document_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"}
+            }
+
+    def test_calibrate_and_apply_flow_passes_ref_for_github_block(self):
+        block = GitHubRepository(
+            repository_url="git@github.com:example-org/example-repo.git"
+        )
+        block._block_document_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        config = PrefectScriptedL2CalibrationConfig(
+            calibration_matrix_version=9,
+            input_json_file="input.json",
+            matlab_repo=block,
+        )
+
+        with (
+            patch(
+                "prefect_server.performCalibration.run_deployment",
+                return_value=self._make_flow_run("child"),
+            ) as mock_run_deployment,
+            patch("prefect_server.performCalibration.calibrate"),
+            patch("prefect_server.performCalibration.apply"),
+        ):
+            calibrate_and_apply_flow.fn(
+                configuration=config,
+                start_date=datetime(2025, 1, 1),
+                end_date=datetime(2025, 1, 2),
+                split_by_day=True,
+            )
+
+        assert mock_run_deployment.call_count == 2
+        for call in mock_run_deployment.call_args_list:
+            configuration_param = call.kwargs["parameters"]["configuration"]
+            assert isinstance(configuration_param, dict)
+            assert configuration_param["matlab_repo"] == {
+                "$ref": {"block_document_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"}
+            }
 
 
 class TestGithubRepoName:


### PR DESCRIPTION
## Problem

When `calibrate_flow` or `calibrate_and_apply_flow` fans out per-day deployment runs via `split_by_day=True`, any `GitHubRepository` or `LocalFileSystem` block in `configuration.matlab_repo` was being serialised by Pydantic's `model_dump()` into a plain field dict. The child run then reconstructed the block from those raw fields — losing the block-store identity and, critically, any credentials stored as a separate block reference (e.g. `GitHubCredentials`).

## Fix

Added `_configuration_for_deployment()` which prepares a `PrefectScriptedL2CalibrationConfig` for passing to `run_deployment`. When `matlab_repo` is a block that was loaded from the block store (i.e. has `_block_document_id` set), it serialises the config to a dict and replaces the block with `{"$ref": {"block_document_id": "..."}}`. Prefect's parameter hydration then resolves the reference in the child run, delivering a fully-authenticated block.

Blocks constructed inline (no `_block_document_id`) fall through unchanged, preserving existing behaviour for local development setups.

Both `calibrate_flow` and `calibrate_and_apply_flow` now call `_configuration_for_deployment()` when building `base_parameters` for `_submit_days_as_deployment_runs`.

## Changes

- `src/prefect_server/performCalibration.py` — new `_configuration_for_deployment()` helper; applied in both split flows
- `tests/unit/test_performCalibration.py` — `TestConfigurationForDeployment` tests the helper directly; `TestSplitByDayWithGithubBlock` verifies the end-to-end split-by-day path for both flows with a `GitHubRepository` block

---
_Generated by [Claude Code](https://claude.ai/code/session_0126NNg25cUzfY6i6uXcPBYg)_