### PR TITLE
fix: forward rotation and reference_frames in calibrate-and-apply split-by-day

### DIFF
--- a/src/prefect_server/performCalibration.py
+++ b/src/prefect_server/performCalibration.py
@@ -444,6 +444,8 @@ def calibrate_and_apply_flow(
                 "L2_output_type": L2_output_type,
                 "save_mode": save_mode,
                 "metakernel": metakernel,
+                "rotation_calibration_file_name": rotation_calibration_file_name,
+                "reference_frames": reference_frames,
             },
         )
 

--- a/tests/unit/test_performCalibration.py
+++ b/tests/unit/test_performCalibration.py
@@ -392,6 +392,39 @@ class TestSplitByDay:
             == f"{PREFECT_CONSTANTS.FLOW_NAMES.CALIBRATE_AND_APPLY}/{PREFECT_CONSTANTS.DEPLOYMENT_NAMES.CALIBRATE_AND_APPLY}"
         )
 
+    def test_calibrate_and_apply_flow_split_by_day_forwards_rotation_and_frames(self):
+        """split_by_day must forward rotation_calibration_file_name and reference_frames to each child run."""
+        from imap_mag.util import ReferenceFrame
+
+        with (
+            patch(
+                "prefect_server.performCalibration.run_deployment",
+                return_value=self._make_flow_run("child"),
+            ) as mock_run_deployment,
+            patch("prefect_server.performCalibration.calibrate"),
+            patch("prefect_server.performCalibration.apply"),
+        ):
+            calibrate_and_apply_flow.fn(
+                configuration=GradiometryConfig(),
+                start_date=datetime(2025, 1, 1),
+                end_date=datetime(2025, 1, 2),
+                split_by_day=True,
+                rotation_calibration_file_name="imap_mag_l2-calibration_20260101_v003.cdf",
+                reference_frames=[ReferenceFrame.SRF, ReferenceFrame.GSE],
+            )
+
+        assert mock_run_deployment.call_count == 2
+        for call in mock_run_deployment.call_args_list:
+            params = call.kwargs["parameters"]
+            assert (
+                params["rotation_calibration_file_name"]
+                == "imap_mag_l2-calibration_20260101_v003.cdf"
+            )
+            assert params["reference_frames"] == [
+                ReferenceFrame.SRF,
+                ReferenceFrame.GSE,
+            ]
+
     def test_apply_flow_splits_range(self):
         with (
             patch(


### PR DESCRIPTION
## Summary

When `split_by_day=True`, `calibrate_and_apply_flow` fans the date range into
one per-day child deployment run. The child runs were built from a
`base_parameters` dict that omitted `rotation_calibration_file_name` and
`reference_frames`, so the rotation CDF was silently dropped and reference
frames fell back to defaults on every child.

The `apply_flow` split-by-day path already passed these two fields correctly —
this fix brings `calibrate_and_apply_flow` into line with it.

## Changes

- `src/prefect_server/performCalibration.py` — add `rotation_calibration_file_name` and `reference_frames` to the `base_parameters` dict in `calibrate_and_apply_flow`'s split-by-day branch.
- `tests/unit/test_performCalibration.py` — new test `test_calibrate_and_apply_flow_split_by_day_forwards_rotation_and_frames` that exercises the bug scenario and asserts both parameters appear in every child run.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CtFxoAUgR9SLW5PTchAGJX)_