### PR TITLE
feat: add version override to apply/apply_flow/calibrate-and-apply

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 requires-python = ">=3.11,<3.13" # blocked by imap_processing https://github.com/IMAP-Science-Operations-Center/imap_processing/blob/dev/pyproject.toml#L17
 name = "imap-mag"
-version = "6.4.2"
+version = "6.4.3"
 description = "Process IMAP data"
 authors = [
   {name = "alastairtree"},

--- a/src/imap_mag/cli/apply.py
+++ b/src/imap_mag/cli/apply.py
@@ -18,6 +18,7 @@ from imap_mag.io.file import (
     CalibrationLayerPathHandler,
     SciencePathHandler,
 )
+from imap_mag.io.file.VersionedPathHandler import VersionedPathHandler
 from imap_mag.util import MAGSensor, ReferenceFrame, ScienceMode
 from mag_toolkit.calibration import (
     CalibrationApplicator,
@@ -27,6 +28,77 @@ from mag_toolkit.calibration import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _validate_offset_version_override(version: int | None) -> int | None:
+    """Validate an integer offset file version override.
+
+    Args:
+        version: The version number to force (1-999), or None for auto-increment.
+
+    Returns:
+        The validated version, or None.
+
+    Raises:
+        ValueError: If the value is a bool, not an integer, or out of range.
+    """
+    if version is None:
+        return None
+    if isinstance(version, bool):
+        raise ValueError("Offset version override must be an integer, not bool.")
+    if not isinstance(version, int):
+        raise ValueError(
+            f"Offset version override must be an integer, got {type(version).__name__}."
+        )
+    if version < 1:
+        raise ValueError(f"Offset version override must be at least 1, got {version}.")
+    if version > 999:
+        raise ValueError(f"Offset version override must be at most 999, got {version}.")
+    logger.warning(
+        f"Offset version override active: forcing offset file to v{version:03d}. "
+        "Existing file at this version may be overwritten."
+    )
+    return version
+
+
+def _validate_l2_version_override(
+    override: tuple[int, int] | None,
+) -> tuple[int, int] | None:
+    """Validate a (major, minor) L2 science file version override tuple.
+
+    Args:
+        override: A (major, minor) pair, or None to use default versioning.
+
+    Returns:
+        The validated pair, or None.
+
+    Raises:
+        ValueError: If any element is a bool, non-integer, negative, or out of range.
+    """
+    if override is None:
+        return None
+
+    major, minor = override
+    for val, name, max_val in [
+        (major, "major", 999),
+        (minor, "minor", 9999),
+    ]:
+        if isinstance(val, bool):
+            raise ValueError(f"L2 version {name} must be an integer, not bool.")
+        if not isinstance(val, int):
+            raise ValueError(
+                f"L2 version {name} must be an integer, got {type(val).__name__}."
+            )
+        if val < 0:
+            raise ValueError(f"L2 version {name} must be non-negative, got {val}.")
+        if val > max_val:
+            raise ValueError(f"L2 version {name} must be at most {max_val}, got {val}.")
+
+    logger.warning(
+        f"L2 version override active: forcing L2-pre science files to v{major:03d}.{minor:04d}. "
+        "Existing files at this version may be overwritten."
+    )
+    return (major, minor)
 
 
 class FileType(Enum):
@@ -166,6 +238,23 @@ def apply(
         ReferenceFrame.RTN,
         ReferenceFrame.DSRF,
     ],
+    offset_version_override: Annotated[
+        int | None,
+        typer.Option(
+            "--offset-version-override",
+            help="Force a specific version number (1-999) for the output offset file "
+            "instead of auto-incrementing. Existing file at that version is overwritten.",
+        ),
+    ] = None,
+    l2_version_override: Annotated[
+        tuple[int, int] | None,
+        typer.Option(
+            "--l2-version-override",
+            help="Force a specific (major, minor) version for output L2-pre science CDF files "
+            "instead of auto-incrementing. Provide as two integers. Existing files at that "
+            "version are overwritten.",
+        ),
+    ] = None,
 ):
     """
     Apply calibration rotation and layers to an input science file.
@@ -200,6 +289,8 @@ def apply(
             save_mode=save_mode,
             spice_metakernel=spice_metakernel,
             reference_frames=reference_frames,
+            offset_version_override=offset_version_override,
+            l2_version_override=l2_version_override,
         )
         current += timedelta(days=1)
 
@@ -215,8 +306,13 @@ def _apply_for_date(
     save_mode: SaveMode,
     spice_metakernel: Path | None,
     reference_frames: list[ReferenceFrame],
+    offset_version_override: int | None = None,
+    l2_version_override: tuple[int, int] | None = None,
 ):
     """Apply calibration layers for a single date."""
+    offset_version_override = _validate_offset_version_override(offset_version_override)
+    l2_version_override = _validate_l2_version_override(l2_version_override)
+
     app_settings = AppSettings()  # type: ignore
     work_folder = app_settings.setup_work_folder_for_command(app_settings.apply)
     initialiseLoggingForCommand(
@@ -294,7 +390,10 @@ def _apply_for_date(
         descriptor=f"l2-{original_input_handler.get_mode().short_name}-offsets",
         start_date=date,
         end_date=date,
-        version=1,
+        version=offset_version_override if offset_version_override is not None else 1,
+        versioning_mode=VersionedPathHandler.VersionMode.USER_OVERRIDE
+        if offset_version_override is not None
+        else VersionedPathHandler.VersionMode.MAX_VERSION_PLUS_ONE,
         extension=offset_file_output_type,
     )
 
@@ -338,10 +437,15 @@ def _apply_for_date(
             )
             continue
 
-        l2_handler.level = "l2-pre"  # set level to l2-pre for the output file naming, as it's pre-release l2
-        l2_handler.version = 1  # set version to 0 for the output file naming
-        l2_handler.version_major = app_settings.version_major
+        l2_handler.level = "l2-pre"
         l2_handler.has_major_version = True
+        if l2_version_override is not None:
+            l2_handler.version_major = l2_version_override[0]
+            l2_handler.version = l2_version_override[1]
+            l2_handler.versioning_mode = VersionedPathHandler.VersionMode.USER_OVERRIDE
+        else:
+            l2_handler.version = 1
+            l2_handler.version_major = app_settings.version_major
         outputManager.add_file(L2_file, l2_handler)
 
     cleanup_workfolder_after_apply(

--- a/src/mag_toolkit/calibration/CalibrationConfig.py
+++ b/src/mag_toolkit/calibration/CalibrationConfig.py
@@ -68,7 +68,7 @@ class ScriptedL2CalibrationConfig(CalibrationConfig):
     matlab_repo: str
     produce_report: bool = False
     write_offsets: CreateOffsets = CreateOffsets.AUTOMATIC
-    version_number_override: Annotated[
+    layer_version_number_override: Annotated[
         ScienceFileVersionConfig | None, Field(default=None)
     ] = None
 

--- a/src/prefect_server/performCalibration.py
+++ b/src/prefect_server/performCalibration.py
@@ -26,6 +26,7 @@ from mag_toolkit.calibration import (
 )
 from mag_toolkit.calibration.CalibrationConfig import (
     GradiometryConfig,
+    ScienceFileVersionConfig,
     ScriptedL2CalibrationConfig,
     SetQualityAndNaNConfig,
 )
@@ -440,12 +441,13 @@ def calibrate_and_apply_flow(
         ),
     ] = None,
     l2_version_override: Annotated[
-        tuple[int, int] | None,
+        ScienceFileVersionConfig | None,
         Field(
+            default=None,
             json_schema_extra={
                 "title": "L2 science file version override",
                 "description": "Force a specific (major, minor) version for output L2-pre science CDF files instead of auto-incrementing. Existing files at that version are overwritten.",
-            }
+            },
         ),
     ] = None,
 ) -> list[FlowRun] | None:
@@ -511,7 +513,9 @@ def calibrate_and_apply_flow(
         if rotation_calibration_file_name
         else None,
         offset_version_override=offset_version_override,
-        l2_version_override=l2_version_override,
+        l2_version_override=(l2_version_override.major, l2_version_override.minor)
+        if l2_version_override is not None
+        else None,
     )
     return None
 
@@ -624,12 +628,13 @@ def apply_flow(
         ),
     ] = None,
     l2_version_override: Annotated[
-        tuple[int, int] | None,
+        ScienceFileVersionConfig | None,
         Field(
+            default=None,
             json_schema_extra={
                 "title": "L2 science file version override",
                 "description": "Force a specific (major, minor) version for output L2-pre science CDF files instead of auto-incrementing. Existing files at that version are overwritten.",
-            }
+            },
         ),
     ] = None,
 ) -> list[FlowRun] | None:
@@ -670,7 +675,9 @@ def apply_flow(
         spice_metakernel=spice_metakernel,
         reference_frames=reference_frames or [],
         offset_version_override=offset_version_override,
-        l2_version_override=l2_version_override,
+        l2_version_override=(l2_version_override.major, l2_version_override.minor)
+        if l2_version_override is not None
+        else None,
     )
 
     return None

--- a/src/prefect_server/performCalibration.py
+++ b/src/prefect_server/performCalibration.py
@@ -430,6 +430,24 @@ def calibrate_and_apply_flow(
         ReferenceFrame.GSE,
         ReferenceFrame.SRF,
     ],
+    offset_version_override: Annotated[
+        int | None,
+        Field(
+            json_schema_extra={
+                "title": "Offset file version override",
+                "description": "Force a specific version number (1-999) for the output offset file instead of auto-incrementing. Existing file at that version is overwritten.",
+            }
+        ),
+    ] = None,
+    l2_version_override: Annotated[
+        tuple[int, int] | None,
+        Field(
+            json_schema_extra={
+                "title": "L2 science file version override",
+                "description": "Force a specific (major, minor) version for output L2-pre science CDF files instead of auto-incrementing. Existing files at that version are overwritten.",
+            }
+        ),
+    ] = None,
 ) -> list[FlowRun] | None:
     days = _days_in_range(start_date, end_date)
     if split_by_day and len(days) > 1:
@@ -446,6 +464,8 @@ def calibrate_and_apply_flow(
                 "metakernel": metakernel,
                 "rotation_calibration_file_name": rotation_calibration_file_name,
                 "reference_frames": reference_frames,
+                "offset_version_override": offset_version_override,
+                "l2_version_override": l2_version_override,
             },
         )
 
@@ -490,6 +510,8 @@ def calibrate_and_apply_flow(
         rotation=Path(rotation_calibration_file_name)
         if rotation_calibration_file_name
         else None,
+        offset_version_override=offset_version_override,
+        l2_version_override=l2_version_override,
     )
     return None
 
@@ -592,6 +614,24 @@ def apply_flow(
         ReferenceFrame.SRF,
     ],
     split_by_day: SplitByDay = False,
+    offset_version_override: Annotated[
+        int | None,
+        Field(
+            json_schema_extra={
+                "title": "Offset file version override",
+                "description": "Force a specific version number (1-999) for the output offset file instead of auto-incrementing. Existing file at that version is overwritten.",
+            }
+        ),
+    ] = None,
+    l2_version_override: Annotated[
+        tuple[int, int] | None,
+        Field(
+            json_schema_extra={
+                "title": "L2 science file version override",
+                "description": "Force a specific (major, minor) version for output L2-pre science CDF files instead of auto-incrementing. Existing files at that version are overwritten.",
+            }
+        ),
+    ] = None,
 ) -> list[FlowRun] | None:
     days = _days_in_range(start_date, end_date)
     if split_by_day and len(days) > 1:
@@ -608,6 +648,8 @@ def apply_flow(
                 "rotation_calibration_file_name": rotation_calibration_file_name,
                 "spice_metakernel": spice_metakernel,
                 "reference_frames": reference_frames,
+                "offset_version_override": offset_version_override,
+                "l2_version_override": l2_version_override,
             },
         )
 
@@ -627,6 +669,8 @@ def apply_flow(
         else None,
         spice_metakernel=spice_metakernel,
         reference_frames=reference_frames or [],
+        offset_version_override=offset_version_override,
+        l2_version_override=l2_version_override,
     )
 
     return None

--- a/src/prefect_server/performCalibration.py
+++ b/src/prefect_server/performCalibration.py
@@ -529,7 +529,7 @@ def _run_calibration(
     save_mode,
     metakernel,
 ) -> list[Path]:
-    version_number_override = None
+    layer_file_version_number_override = None
     if type(configuration) is PrefectScriptedL2CalibrationConfig:
         app_settings = AppSettings()  # type: ignore
         # Pull/resolve the MATLAB code into the (stable) base work folder so it is
@@ -548,12 +548,12 @@ def _run_calibration(
         configuration = configuration.model_copy(
             update={"matlab_repo": str(matlab_repo_path)}
         )
-        version_number_override = (
+        layer_file_version_number_override = (
             (
-                configuration.version_number_override.major,
-                configuration.version_number_override.minor,
+                configuration.layer_version_number_override.major,
+                configuration.layer_version_number_override.minor,
             )
-            if configuration.version_number_override
+            if configuration.layer_version_number_override
             else None
         )
 
@@ -573,7 +573,7 @@ def _run_calibration(
         save_mode=save_mode,
         metakernel=metakernel,
         cleanup_temp_files_after_run=configuration.cleanup_temp_files_after_run,
-        version_number_override=version_number_override,
+        version_number_override=layer_file_version_number_override,
     )
 
     return output_file_paths

--- a/tests/integration/test_apply.py
+++ b/tests/integration/test_apply.py
@@ -494,3 +494,81 @@ def test_apply_data_store_is_cwd_when_spice_kernels_are_accessed(
         f"active CWD; if CWD changes before the computation finishes the "
         f"reconnect fails with SpiceFILEOPENFAIL on large production kernels."
     )
+
+
+def test_apply_offset_version_override_forces_specific_version(
+    temp_datastore,
+    dynamic_work_folder,
+    spice_kernels,
+):
+    """offset_version_override must write the offset file at the forced version
+    instead of auto-incrementing, overwriting any existing file at that slot."""
+    offsets_dir = temp_datastore / "science-ancillary/l2-offsets/2026/01"
+    offsets_dir.mkdir(parents=True, exist_ok=True)
+    existing = offsets_dir / "imap_mag_l2-norm-offsets_20260116_20260116_v005.cdf"
+    existing.write_bytes(b"old content")
+
+    apply(
+        layers=["imap_mag_noop-norm-layer_20260116_v001.json"],
+        input="imap_mag_l1c_norm-mago_20260116_v001.cdf",
+        start_date=datetime(2026, 1, 16),
+        offset_version_override=5,
+    )
+
+    assert existing.exists(), "Offset file must exist at the forced version v005"
+    assert existing.stat().st_size > len(b"old content"), (
+        "Offset file at forced version must have been overwritten with real content"
+    )
+    assert not (
+        offsets_dir / "imap_mag_l2-norm-offsets_20260116_20260116_v006.cdf"
+    ).exists(), "Auto-incremented v006 must not be created when override is active"
+
+
+def test_apply_l2_version_override_forces_specific_version(
+    temp_datastore,
+    dynamic_work_folder,
+    spice_kernels,
+):
+    """l2_version_override must write all L2-pre science files at the forced
+    (major, minor) version instead of auto-incrementing."""
+    apply(
+        layers=["imap_mag_noop-norm-layer_20260116_v001.json"],
+        input="imap_mag_l1c_norm-mago_20260116_v001.cdf",
+        start_date=datetime(2026, 1, 16),
+        l2_version_override=(2, 5),
+    )
+
+    l2_dir = temp_datastore / "science/mag/l2-pre/2026/01"
+    forced_srf = l2_dir / "imap_mag_l2-pre_norm-srf_20260116_v002.0005.cdf"
+    assert forced_srf.exists(), (
+        "L2-pre SRF file must exist at the forced version v002.0005"
+    )
+    assert not (l2_dir / "imap_mag_l2-pre_norm-srf_20260116_v001.0001.cdf").exists(), (
+        "Default v001.0001 must not be created when the L2 version override is active"
+    )
+
+
+def test_apply_l2_version_override_overwrites_existing_file(
+    temp_datastore,
+    dynamic_work_folder,
+    spice_kernels,
+):
+    """When l2_version_override targets a slot that already has a file with
+    different content, the new file replaces it in the datastore."""
+    l2_dir = temp_datastore / "science/mag/l2-pre/2026/01"
+    l2_dir.mkdir(parents=True, exist_ok=True)
+    existing = l2_dir / "imap_mag_l2-pre_norm-srf_20260116_v003.0007.cdf"
+    existing.write_bytes(b"stale content")
+    original_mtime = existing.stat().st_mtime
+
+    apply(
+        layers=["imap_mag_noop-norm-layer_20260116_v001.json"],
+        input="imap_mag_l1c_norm-mago_20260116_v001.cdf",
+        start_date=datetime(2026, 1, 16),
+        l2_version_override=(3, 7),
+    )
+
+    assert existing.exists()
+    assert existing.stat().st_mtime != original_mtime, (
+        "Existing L2 file at the forced version must have been overwritten"
+    )

--- a/tests/integration/test_performCalibration.py
+++ b/tests/integration/test_performCalibration.py
@@ -1,9 +1,12 @@
-from datetime import datetime
+from datetime import date, datetime
+from unittest.mock import patch
 
 from imap_mag.config import SaveMode
 from imap_mag.util import ScienceMode
+from mag_toolkit.calibration.CalibrationConfig import GradiometryConfig
 from prefect_server.performCalibration import (
     apply_flow,
+    calibrate_and_apply_flow,
 )
 from tests.util.miscellaneous import open_cdf
 from tests.util.prefect_test_utils import prefect_test_fixture  # noqa: F401
@@ -22,16 +25,16 @@ def test_apply_flow_resolves_layer_patterns_and_discovers_science_file(
         save_mode=SaveMode.LocalOnly,
     )
 
-    date = datetime(2026, 1, 16)
+    date_ = datetime(2026, 1, 16)
     output_l2_file = (
         temp_datastore
-        / f"science/mag/l2-pre/{date.year}/{date.month:02d}/imap_mag_l2-pre_norm-srf_{date.year}{date.month:02d}{date.day:02d}_v001.0001.cdf"
+        / f"science/mag/l2-pre/{date_.year}/{date_.month:02d}/imap_mag_l2-pre_norm-srf_{date_.year}{date_.month:02d}{date_.day:02d}_v001.0001.cdf"
     )
     assert output_l2_file.exists()
 
     output_offsets_file = (
         temp_datastore
-        / f"science-ancillary/l2-offsets/{date.year}/{date.month:02d}/imap_mag_l2-norm-offsets_{date.year}{date.month:02d}{date.day:02d}_{date.year}{date.month:02d}{date.day:02d}_v001.cdf"
+        / f"science-ancillary/l2-offsets/{date_.year}/{date_.month:02d}/imap_mag_l2-norm-offsets_{date_.year}{date_.month:02d}{date_.day:02d}_{date_.year}{date_.month:02d}{date_.day:02d}_v001.cdf"
     )
     assert output_offsets_file.exists()
 
@@ -39,3 +42,98 @@ def test_apply_flow_resolves_layer_patterns_and_discovers_science_file(
         assert "b_srf" in cdf
         assert "epoch" in cdf
         assert "magnitude" in cdf
+
+
+def test_apply_flow_offset_version_override(
+    temp_datastore,
+    dynamic_work_folder,
+    spice_kernels,
+    prefect_test_fixture,  # noqa: F811
+):
+    """apply_flow must honour offset_version_override and write the offset file
+    at the forced version, overwriting any existing placeholder at that slot."""
+    offsets_dir = temp_datastore / "science-ancillary/l2-offsets/2026/01"
+    offsets_dir.mkdir(parents=True, exist_ok=True)
+    existing = offsets_dir / "imap_mag_l2-norm-offsets_20260116_20260116_v007.cdf"
+    existing.write_bytes(b"old content")
+
+    apply_flow(
+        layers=["*noop*"],
+        start_date=datetime(2026, 1, 16),
+        mode=ScienceMode.Normal,
+        save_mode=SaveMode.LocalOnly,
+        offset_version_override=7,
+    )
+
+    assert existing.exists()
+    assert existing.stat().st_size > len(b"old content"), (
+        "Offset file must have been overwritten with real content at v007"
+    )
+    assert not (
+        offsets_dir / "imap_mag_l2-norm-offsets_20260116_20260116_v008.cdf"
+    ).exists(), "No auto-increment to v008 when override is active"
+
+
+def test_apply_flow_l2_version_override(
+    temp_datastore,
+    dynamic_work_folder,
+    spice_kernels,
+    prefect_test_fixture,  # noqa: F811
+):
+    """apply_flow must honour l2_version_override and produce L2-pre science files
+    at the forced (major, minor) version."""
+    apply_flow(
+        layers=["*noop*"],
+        start_date=datetime(2026, 1, 16),
+        mode=ScienceMode.Normal,
+        save_mode=SaveMode.LocalOnly,
+        l2_version_override=(3, 9),
+    )
+
+    l2_dir = temp_datastore / "science/mag/l2-pre/2026/01"
+    forced = l2_dir / "imap_mag_l2-pre_norm-srf_20260116_v003.0009.cdf"
+    assert forced.exists(), "L2-pre SRF file must exist at forced version v003.0009"
+    assert not (l2_dir / "imap_mag_l2-pre_norm-srf_20260116_v001.0001.cdf").exists(), (
+        "Default v001.0001 must not appear when L2 version override is active"
+    )
+
+
+def test_calibrate_and_apply_flow_with_version_overrides(
+    temp_datastore,
+    dynamic_work_folder,
+    spice_kernels,
+):
+    """calibrate_and_apply_flow must forward offset_version_override and
+    l2_version_override to the apply step, producing output files at the
+    forced versions.
+
+    The calibration step is mocked to return the real noop layer that already
+    exists in the test datastore so the apply step runs end-to-end.
+    """
+    layer_path = (
+        temp_datastore
+        / "calibration/layers/2026/01/imap_mag_noop-norm-layer_20260116_v001.json"
+    )
+
+    with patch(
+        "prefect_server.performCalibration._run_calibration",
+        return_value=[layer_path],
+    ):
+        calibrate_and_apply_flow.fn(
+            start_date=date(2026, 1, 16),
+            configuration=GradiometryConfig(kappa=0.0, sc_interference_threshold=0.0),
+            mode=ScienceMode.Normal,
+            save_mode=SaveMode.LocalOnly,
+            offset_version_override=4,
+            l2_version_override=(2, 8),
+        )
+
+    offsets_dir = temp_datastore / "science-ancillary/l2-offsets/2026/01"
+    assert (
+        offsets_dir / "imap_mag_l2-norm-offsets_20260116_20260116_v004.cdf"
+    ).exists(), "Offset file must be at forced version v004"
+
+    l2_dir = temp_datastore / "science/mag/l2-pre/2026/01"
+    assert (l2_dir / "imap_mag_l2-pre_norm-srf_20260116_v002.0008.cdf").exists(), (
+        "L2-pre SRF file must be at forced version v002.0008"
+    )

--- a/tests/integration/test_performCalibration.py
+++ b/tests/integration/test_performCalibration.py
@@ -3,7 +3,10 @@ from unittest.mock import patch
 
 from imap_mag.config import SaveMode
 from imap_mag.util import ScienceMode
-from mag_toolkit.calibration.CalibrationConfig import GradiometryConfig
+from mag_toolkit.calibration.CalibrationConfig import (
+    GradiometryConfig,
+    ScienceFileVersionConfig,
+)
 from prefect_server.performCalibration import (
     apply_flow,
     calibrate_and_apply_flow,
@@ -87,7 +90,7 @@ def test_apply_flow_l2_version_override(
         start_date=datetime(2026, 1, 16),
         mode=ScienceMode.Normal,
         save_mode=SaveMode.LocalOnly,
-        l2_version_override=(3, 9),
+        l2_version_override=ScienceFileVersionConfig(major=3, minor=9),
     )
 
     l2_dir = temp_datastore / "science/mag/l2-pre/2026/01"
@@ -125,7 +128,7 @@ def test_calibrate_and_apply_flow_with_version_overrides(
             mode=ScienceMode.Normal,
             save_mode=SaveMode.LocalOnly,
             offset_version_override=4,
-            l2_version_override=(2, 8),
+            l2_version_override=ScienceFileVersionConfig(major=2, minor=8),
         )
 
     offsets_dir = temp_datastore / "science-ancillary/l2-offsets/2026/01"


### PR DESCRIPTION
## Summary

- Adds `offset_version_override` (int 1–999) parameter to `apply()`, `apply_flow()`, and `calibrate_and_apply_flow()`: forces the output offset CDF file to be written at the specified version, overwriting any existing file at that slot instead of auto-incrementing.
- Adds `l2_version_override` (major, minor tuple) parameter to the same three entry points: forces all L2-pre science CDF files to use the specified `(major, minor)` version, again overwriting in place.
- Both new parameters default to `None`, preserving the existing max+1 auto-increment behaviour unchanged for all existing callers.
- Parameters thread through the `split_by_day` deployment re-submission path in both Prefect flows.
- Validates inputs early with clear `ValueError` messages (bool/non-integer/out-of-range checks).

## Test plan

- [ ] Run `poetry run pytest tests/integration/test_apply.py -k "version_override" -v` — 3 new integration tests covering offset and L2 version overrides in the `apply()` CLI function.
- [ ] Run `poetry run pytest tests/integration/test_performCalibration.py -v` — 3 new integration tests covering `apply_flow` offset override, `apply_flow` L2 override, and `calibrate_and_apply_flow` with both overrides (calibration step mocked; apply step runs end-to-end with real SPICE kernels and test data).
- [ ] Run `poetry run pytest tests/unit/test_apply.py tests/unit/test_performCalibration.py` — all existing unit tests still pass.