### PR TITLE
feat: add overwrite_option to poll-science flow for controlled datastore file replacement

### DIFF
--- a/src/imap_mag/cli/calibrate.py
+++ b/src/imap_mag/cli/calibrate.py
@@ -160,7 +160,7 @@ def _save_calibration_outputs(
                 path, createDirectory=False, save_contents=False
             )
 
-        destination, _ = outputManager.add_file(path, path_handler=handler)
+        destination, _, _ = outputManager.add_file(path, path_handler=handler)
         saved_file_paths.append(destination)
 
         if companion_path:

--- a/src/imap_mag/cli/fetch/binary.py
+++ b/src/imap_mag/cli/fetch/binary.py
@@ -103,7 +103,7 @@ def fetch_binary(
         )
 
         for file, path_handler in downloaded_binaries.items():
-            (output_file, output_handler) = datastore_manager.add_file(
+            (output_file, output_handler, _) = datastore_manager.add_file(
                 file, path_handler
             )
             output_binaries[output_file] = output_handler

--- a/src/imap_mag/cli/fetch/ialirt.py
+++ b/src/imap_mag/cli/fetch/ialirt.py
@@ -68,7 +68,9 @@ def _publish_files(
 
     result: dict[Path, IALiRTPathHandler] = dict()
     for file, path_handler in downloaded_files.items():
-        (output_file, output_handler) = datastore_manager.add_file(file, path_handler)
+        (output_file, output_handler, _) = datastore_manager.add_file(
+            file, path_handler
+        )
         result[output_file] = output_handler
 
     return result

--- a/src/imap_mag/cli/fetch/science.py
+++ b/src/imap_mag/cli/fetch/science.py
@@ -135,7 +135,7 @@ def fetch_science(
         )
 
         for file, path_handler in downloaded_science.items():
-            (output_file, output_handler) = datastore_manager.add_file(
+            (output_file, output_handler, _) = datastore_manager.add_file(
                 file, path_handler
             )
             output_science[output_file] = output_handler

--- a/src/imap_mag/cli/fetch/science.py
+++ b/src/imap_mag/cli/fetch/science.py
@@ -7,7 +7,7 @@ import typer
 
 from imap_mag.cli.cliUtils import initialiseLoggingForCommand
 from imap_mag.client.SDCDataAccess import SDCDataAccess
-from imap_mag.config import AppSettings, FetchMode
+from imap_mag.config import AppSettings, DatastoreSaveOption, FetchMode
 from imap_mag.download.FetchScience import FetchScience
 from imap_mag.io import DatastoreFileManager
 from imap_mag.io.file import SciencePathHandler
@@ -71,6 +71,13 @@ def fetch_science(
             help="Number of items to skip from the start of the query results. Useful for batching downloads.",
         ),
     ] = 0,
+    overwrite_option: Annotated[
+        DatastoreSaveOption,
+        typer.Option(
+            case_sensitive=False,
+            help="Whether to block or allow overwriting an existing datastore file that has the same version but different content.",
+        ),
+    ] = DatastoreSaveOption.FILE_OVERWRITES_BLOCKED,
 ) -> dict[Path, SciencePathHandler]:
     """Download science data from the SDC."""
 
@@ -116,6 +123,11 @@ def fetch_science(
     output_science: dict[Path, SciencePathHandler] = dict()
 
     if app_settings.fetch_science.publish_to_data_store:
+        if overwrite_option == DatastoreSaveOption.FILE_OVERWRITES_ALLOWED:
+            for path_handler in downloaded_science.values():
+                path_handler.allow_overwrite = True
+                path_handler.version_is_locked = False
+
         datastore_manager = DatastoreFileManager.CreateByMode(
             app_settings,
             use_database=(fetch_mode == FetchMode.DownloadAndUpdateProgress),

--- a/src/imap_mag/cli/fetch/science.py
+++ b/src/imap_mag/cli/fetch/science.py
@@ -126,7 +126,8 @@ def fetch_science(
         if overwrite_option == DatastoreSaveOption.FILE_OVERWRITES_ALLOWED:
             for path_handler in downloaded_science.values():
                 path_handler.allow_overwrite = True
-                path_handler.version_is_locked = False
+                # version_is_locked deliberately kept True — SDC science file versions must
+                # never be reassigned, only the file bytes are overwritten in place.
 
         datastore_manager = DatastoreFileManager.CreateByMode(
             app_settings,

--- a/src/imap_mag/cli/fetch/spice.py
+++ b/src/imap_mag/cli/fetch/spice.py
@@ -318,7 +318,9 @@ def fetch_spice(
 
         handler.add_metadata(file_metadata)
         if output_manager is not None:
-            (output_file, output_handler) = output_manager.add_file(file_path, handler)
+            (output_file, output_handler, _) = output_manager.add_file(
+                file_path, handler
+            )
             output_spice.append((output_file, output_handler, file_metadata))
         else:
             output_spice.append((file_path, handler, file_metadata))
@@ -555,7 +557,7 @@ def publish_spice_kernel(
             f"Downloaded SPICE file {kernal_file_path} could not be parsed into SPICEPathHandler"
         )
 
-    (output_file, _) = output_manager.add_file(kernal_file_path, handler)
+    (output_file, _, _) = output_manager.add_file(kernal_file_path, handler)
 
     return output_file
 

--- a/src/imap_mag/cli/plot/plot_ialirt.py
+++ b/src/imap_mag/cli/plot/plot_ialirt.py
@@ -119,7 +119,7 @@ def plot_ialirt(
         )
 
         for file, path_handler in generated_figure.items():
-            (output_file, output_handler) = datastore_manager.add_file(
+            (output_file, output_handler, _) = datastore_manager.add_file(
                 file, path_handler
             )
             ialirt_file_and_handler[output_file] = output_handler

--- a/src/imap_mag/cli/process.py
+++ b/src/imap_mag/cli/process.py
@@ -82,7 +82,7 @@ def process(
     copied_files: list[tuple[Path, IFilePathHandler]] = []
 
     for processed_file, path_handler in processed_files.items():
-        (copied_file, path_handler) = datastore_manager.add_file(
+        (copied_file, path_handler, _) = datastore_manager.add_file(
             processed_file, path_handler
         )
 

--- a/src/imap_mag/config/DatastoreSaveOption.py
+++ b/src/imap_mag/config/DatastoreSaveOption.py
@@ -1,0 +1,8 @@
+from enum import StrEnum
+
+
+class DatastoreSaveOption(StrEnum):
+    """Controls overwrite behaviour when saving files to the datastore."""
+
+    FILE_OVERWRITES_BLOCKED = "FILE_OVERWRITES_BLOCKED"
+    FILE_OVERWRITES_ALLOWED = "FILE_OVERWRITES_ALLOWED"

--- a/src/imap_mag/config/__init__.py
+++ b/src/imap_mag/config/__init__.py
@@ -6,6 +6,7 @@ from imap_mag.config.CalibrationCommandConfig import (
     SparseDatastorePattern,
 )
 from imap_mag.config.CommandConfig import CommandConfig
+from imap_mag.config.DatastoreSaveOption import DatastoreSaveOption
 from imap_mag.config.FetchConfig import FetchBinaryConfig, FetchScienceConfig
 from imap_mag.config.FetchMode import FetchMode
 from imap_mag.config.NestedAliasEnvSettingsSource import NestedAliasEnvSettingsSource
@@ -24,6 +25,7 @@ __all__ = [
     "CalibrationCommandConfig",
     "CalibrationConfig",
     "CommandConfig",
+    "DatastoreSaveOption",
     "FetchBinaryConfig",
     "FetchMode",
     "FetchScienceConfig",

--- a/src/imap_mag/data_pipelines/DownloadSmallForcesFilesStage.py
+++ b/src/imap_mag/data_pipelines/DownloadSmallForcesFilesStage.py
@@ -116,7 +116,7 @@ class DownloadSmallForcesFilesStage(Stage):
             # Publish to datastore with metadata preserved
             output_file = downloaded_file
             if output_manager is not None:
-                (output_file, _) = output_manager.add_file(downloaded_file, handler)
+                (output_file, _, _) = output_manager.add_file(downloaded_file, handler)
 
             # Update progress to the latest ingestion date
             if ingestion_date:

--- a/src/imap_mag/data_pipelines/DownloadSpinTableFilesStage.py
+++ b/src/imap_mag/data_pipelines/DownloadSpinTableFilesStage.py
@@ -114,7 +114,7 @@ class DownloadSpinTableFilesStage(Stage):
             # Publish to datastore with metadata preserved
             output_file = downloaded_file
             if output_manager is not None:
-                (output_file, _) = output_manager.add_file(downloaded_file, handler)
+                (output_file, _, _) = output_manager.add_file(downloaded_file, handler)
 
             # Update progress to the latest ingestion date
             if ingestion_date:

--- a/src/imap_mag/data_pipelines/PublishFileToDatastoreStage.py
+++ b/src/imap_mag/data_pipelines/PublishFileToDatastoreStage.py
@@ -53,7 +53,7 @@ class PublishFileToDatastoreStage(Stage):
                 f"Could not determine content date for file {file_path}, cannot publish to datastore"
             )
 
-        saved_path, _ = self.datastore_manager.add_file(file_path, path_handler)
+        saved_path, _, _ = self.datastore_manager.add_file(file_path, path_handler)
 
         self.files_saved += 1
         await self.publish_next(FileRecord(saved_path, content_date), context, **kwargs)

--- a/src/imap_mag/db/Database.py
+++ b/src/imap_mag/db/Database.py
@@ -92,7 +92,7 @@ class Database:
         session = self.__get_active_session()
         for file in files:
             # check file does not already exist if this is a new file record (id is none)
-            if file.id is None:
+            if file.id is None or file.id == 0:
                 existing_file = (
                     session.query(File)
                     .filter_by(name=file.name, path=file.path)

--- a/src/imap_mag/io/DBIndexedDatastoreFileManager.py
+++ b/src/imap_mag/io/DBIndexedDatastoreFileManager.py
@@ -328,7 +328,7 @@ class DBIndexedDatastoreFileManager(IDatastoreFileManager):
 
         if matching_files:
             if path_handler.get_sequence() != matching_files[0].version:
-                if getattr(path_handler, "allow_overwrite", False):
+                if path_handler.allow_overwrite:
                     logger.warning(
                         f"File with same content as {original_file.name} already exists in database "
                         f"at version {matching_files[0].version}. Proceeding to save at downloaded "
@@ -348,7 +348,7 @@ class DBIndexedDatastoreFileManager(IDatastoreFileManager):
         # unique-constraint conflict by soft-deleting active DB records that share
         # the same minor version but a different path — those represent the file
         # being overwritten at the operator-supplied version.
-        if getattr(path_handler, "allow_overwrite", False):
+        if path_handler.allow_overwrite:
             forced_minor = path_handler.get_sequence()
             new_destination = path_handler.get_full_path(self.__settings.data_store)
             conflicting = [

--- a/src/imap_mag/io/DBIndexedDatastoreFileManager.py
+++ b/src/imap_mag/io/DBIndexedDatastoreFileManager.py
@@ -328,11 +328,21 @@ class DBIndexedDatastoreFileManager(IDatastoreFileManager):
 
         if matching_files:
             if path_handler.get_sequence() != matching_files[0].version:
-                logger.info(
-                    f"File with same content as {original_file.name} already exists in database at version {matching_files[0].version}. Reusing."
-                )
-                path_handler.set_sequence(matching_files[0].version)
-            return True
+                if getattr(path_handler, "allow_overwrite", False):
+                    logger.warning(
+                        f"File with same content as {original_file.name} already exists in database "
+                        f"at version {matching_files[0].version}. Proceeding to save at downloaded "
+                        f"version {path_handler.get_sequence()} as overwrite is allowed."
+                    )
+                    # Fall through to the allow_overwrite block — save at the downloaded version.
+                else:
+                    logger.info(
+                        f"File with same content as {original_file.name} already exists in database at version {matching_files[0].version}. Reusing."
+                    )
+                    path_handler.set_sequence(matching_files[0].version)
+                    return True
+            else:
+                return True
 
         # Version override: keep the forced version (no max+1 walk). Resolve any
         # unique-constraint conflict by soft-deleting active DB records that share

--- a/src/imap_mag/io/DBIndexedDatastoreFileManager.py
+++ b/src/imap_mag/io/DBIndexedDatastoreFileManager.py
@@ -53,7 +53,7 @@ class DBIndexedDatastoreFileManager(IDatastoreFileManager):
         else:
             self.__database = database
 
-    def add_file(self, original_file: Path, path_handler: T) -> tuple[Path, T]:
+    def add_file(self, original_file: Path, path_handler: T) -> tuple[Path, T, bool]:
         # Determine the version: reuse an existing one if content is identical,
         # otherwise advance to the next available slot.
         skip_database_insertion: bool = self.__get_next_available_version(
@@ -70,12 +70,12 @@ class DBIndexedDatastoreFileManager(IDatastoreFileManager):
         else:
             actual_source = original_file
 
-        (destination_file, path_handler) = self.__file_manager.add_file(
+        (destination_file, path_handler, overwritten) = self.__file_manager.add_file(
             actual_source, path_handler
         )
 
         # Add file to database
-        if skip_database_insertion:
+        if skip_database_insertion and not overwritten:
             logger.info(
                 f"File {destination_file} already exists in database with same hash. Skipping database update."
             )
@@ -90,7 +90,7 @@ class DBIndexedDatastoreFileManager(IDatastoreFileManager):
                 destination_file.unlink()
                 raise e
 
-        return (destination_file, path_handler)
+        return (destination_file, path_handler, overwritten)
 
     def archive_file(
         self,
@@ -348,6 +348,9 @@ class DBIndexedDatastoreFileManager(IDatastoreFileManager):
         # unique-constraint conflict by soft-deleting active DB records that share
         # the same minor version but a different path — those represent the file
         # being overwritten at the operator-supplied version.
+        # in normal operations this should never happen because paths are well
+        # defined and a match by version+descriptor would have the same path and
+        # so would not be soft deleted, it would just update the existing file record.
         if path_handler.allow_overwrite:
             forced_minor = path_handler.get_sequence()
             new_destination = path_handler.get_full_path(self.__settings.data_store)

--- a/src/imap_mag/io/DBIndexedDatastoreFileManager.py
+++ b/src/imap_mag/io/DBIndexedDatastoreFileManager.py
@@ -358,7 +358,7 @@ class DBIndexedDatastoreFileManager(IDatastoreFileManager):
                     path_handler.set_sequence(matching_files[0].version)
                     return IDENTICAL_FILE_ALREADY_EXISTS
             else:
-                logger.info(
+                logger.debug(
                     f"File with same content and version as {original_file.name} already in database. Reusing."
                 )
                 return IDENTICAL_FILE_ALREADY_EXISTS

--- a/src/imap_mag/io/DBIndexedDatastoreFileManager.py
+++ b/src/imap_mag/io/DBIndexedDatastoreFileManager.py
@@ -288,15 +288,24 @@ class DBIndexedDatastoreFileManager(IDatastoreFileManager):
     ) -> bool:
         """Find a viable version for a file, returning True if the file already exists unchanged."""
 
+        IDENTICAL_FILE_ALREADY_EXISTS = True
+        FILE_IS_NEW = False
+
         if not path_handler.supports_sequencing():
             logger.debug(
                 "Versioning not supported. File may be overwritten if it already exists and is different."
             )
-            return False
+            return FILE_IS_NEW
         else:
             assert isinstance(path_handler, SequenceablePathHandler)
 
         database_files: list[File] = self.__get_matching_database_files(path_handler)
+
+        if not database_files:
+            logger.debug(
+                f"No existing files found in database for {original_file.name}. Proceeding to add as new."
+            )
+            return FILE_IS_NEW
 
         # Check whether an existing version has the same content identity
         identity_hash: str = path_handler.get_content_identity(original_file)
@@ -320,7 +329,7 @@ class DBIndexedDatastoreFileManager(IDatastoreFileManager):
                 key=lambda f: (f.version_major, f.version),
                 reverse=True,
             )
-            logger.warning(
+            logger.info(
                 f"Found {duplicate_count} records with identical content identity for "
                 f"{original_file.name}. "
                 f"Reusing version {matching_files[0].version_major}.{matching_files[0].version}."
@@ -335,14 +344,24 @@ class DBIndexedDatastoreFileManager(IDatastoreFileManager):
                         f"version {path_handler.get_sequence()} as overwrite is allowed."
                     )
                     # Fall through to the allow_overwrite block — save at the downloaded version.
+                elif not path_handler.can_change_sequence():
+                    logger.warning(
+                        f"File with same content as {original_file.name} already exists in database "
+                        f"at version {matching_files[0].version}. This should not happen for supposedly unique files! "
+                        f"Proceeding to save at downloaded version {path_handler.get_sequence()} as this is a locked science file."
+                    )
+                    # Fall through to the other options below
                 else:
                     logger.info(
-                        f"File with same content as {original_file.name} already exists in database at version {matching_files[0].version}. Reusing."
+                        f"File with same content as {original_file.name} already exists in database at different version {matching_files[0].version}. Reusing that version."
                     )
                     path_handler.set_sequence(matching_files[0].version)
-                    return True
+                    return IDENTICAL_FILE_ALREADY_EXISTS
             else:
-                return True
+                logger.info(
+                    f"File with same content and version as {original_file.name} already in database. Reusing."
+                )
+                return IDENTICAL_FILE_ALREADY_EXISTS
 
         # Version override: keep the forced version (no max+1 walk). Resolve any
         # unique-constraint conflict by soft-deleting active DB records that share
@@ -373,20 +392,32 @@ class DBIndexedDatastoreFileManager(IDatastoreFileManager):
                 self.__database.upsert_file(conflict)
                 if conflict_path.exists():
                     conflict_path.unlink()
-            return False
+            return FILE_IS_NEW
 
         # Assign max+1 rather than the first available slot so version numbers are
         # monotonically increasing even when earlier versions have been deleted or
         # never existed (e.g. existing versions {2} → next is 3, not 1).
         existing_versions: set[int] = set(file.version for file in database_files)
+        next_version = max(existing_versions) + 1
 
-        if existing_versions:
-            next_version = max(existing_versions) + 1
-            if path_handler.get_sequence() < next_version:
-                logger.debug(
-                    f"Existing versions {sorted(existing_versions)} found in database. "
-                    f"Assigning next version {next_version} (max + 1)."
-                )
-                path_handler.set_sequence(next_version)
+        if path_handler.get_sequence() >= next_version:
+            return FILE_IS_NEW
 
-        return False
+        if (
+            path_handler.get_sequence() < next_version
+            and path_handler.can_change_sequence()
+        ):
+            logger.info(
+                f"Existing versions {sorted(existing_versions)} found in database. "
+                f"Assigning next available version {next_version} (max + 1)."
+            )
+
+            path_handler.set_sequence(next_version)
+            return FILE_IS_NEW
+
+        raise ValueError(
+            f"Cannot proceed with adding file {original_file.name}."
+            f"Existing version(s) {sorted(existing_versions)} found in database with "
+            "different content which cannot be overwritten without allow_overwrite "
+            "option and we are not allowed to re-version this type of file"
+        )

--- a/src/imap_mag/io/DatastoreFileManager.py
+++ b/src/imap_mag/io/DatastoreFileManager.py
@@ -129,7 +129,7 @@ class DatastoreFileManager(IDatastoreFileManager):
             assert isinstance(path_handler, SequenceablePathHandler)
 
         # Version override: skip up-versioning and overwrite the exact version in place.
-        if getattr(path_handler, "allow_overwrite", False):
+        if path_handler.allow_overwrite:
             if not destination_file.exists():
                 return False
             orig_identity = path_handler.get_content_identity(original_file)

--- a/src/imap_mag/io/DatastoreFileManager.py
+++ b/src/imap_mag/io/DatastoreFileManager.py
@@ -28,8 +28,9 @@ class DatastoreFileManager(IDatastoreFileManager):
     def _check_disk_space(self) -> None:
         check_disk_space(self.location, self.disk_usage_threshold)
 
-    def add_file(self, original_file: Path, path_handler: T) -> tuple[Path, T]:
-        """Add file to output location."""
+    def add_file(self, original_file: Path, path_handler: T) -> tuple[Path, T, bool]:
+        """Add file to output location.
+        Returns the destination file path and the path handler used to generate it and a bool indicating if an overwrite occured"""
 
         if not original_file.exists():
             logger.error(f"File {original_file} does not exist.")
@@ -51,13 +52,13 @@ class DatastoreFileManager(IDatastoreFileManager):
             logger.info(
                 f"Source and destination files are the same ({original_file}). Skipping update."
             )
-            return (destination_file, path_handler)
+            return (destination_file, path_handler, False)
 
         elif skip_file_copy:
             logger.info(
                 f"File {destination_file} already exists and is the same - skip copy into datastore."
             )
-            return (destination_file, path_handler)
+            return (destination_file, path_handler, False)
 
         elif not destination_file.parent.exists():
             logger.debug(
@@ -67,8 +68,11 @@ class DatastoreFileManager(IDatastoreFileManager):
 
         # Allow the handler to rewrite the source (e.g. update version references in JSON).
         source_file_after_reversioning = path_handler.prepare_for_version(original_file)
+        destination_overwritten = destination_file.exists()
         try:
-            logger.info(f"Copying {original_file} to {destination_file.absolute()}.")
+            logger.info(
+                f"Copying {original_file} to {destination_file.absolute()}. ({'overwriting' if destination_overwritten else 'new'})"
+            )
             destination = shutil.copy2(source_file_after_reversioning, destination_file)
             logger.debug(f"Copied to {destination}.")
             self.verify_file_delivered_to_datastore(
@@ -81,7 +85,7 @@ class DatastoreFileManager(IDatastoreFileManager):
             ):
                 source_file_after_reversioning.unlink()
 
-        return (destination_file, path_handler)
+        return (destination_file, path_handler, destination_overwritten)
 
     def verify_file_delivered_to_datastore(
         self, original_file, source_file_after_reversioning, destination_file

--- a/src/imap_mag/io/IDatastoreFileManager.py
+++ b/src/imap_mag/io/IDatastoreFileManager.py
@@ -11,5 +11,5 @@ class IDatastoreFileManager(abc.ABC):
     """Interface for output managers."""
 
     @abc.abstractmethod
-    def add_file(self, original_file: Path, path_handler: T) -> tuple[Path, T]:
-        """Add file to output location."""
+    def add_file(self, original_file: Path, path_handler: T) -> tuple[Path, T, bool]:
+        """Add file to output location. Returns the destination file path, the path handler used to generate it, and a bool indicating if an overwrite occurred."""

--- a/src/imap_mag/io/file/SciencePathHandler.py
+++ b/src/imap_mag/io/file/SciencePathHandler.py
@@ -56,6 +56,9 @@ class SciencePathHandler(StandardSPDFPathHandler):
 
         super().set_sequence(sequence)
 
+    def can_change_sequence(self) -> bool:
+        return not self.version_is_locked and super().can_change_sequence()
+
     def increase_sequence(self) -> None:
         if self.version_is_locked:
             raise ValueError(

--- a/src/imap_mag/io/file/SequenceablePathHandler.py
+++ b/src/imap_mag/io/file/SequenceablePathHandler.py
@@ -30,6 +30,10 @@ class SequenceablePathHandler(IFilePathHandler):
         """Set the sequence count."""
         pass
 
+    def can_change_sequence(self) -> bool:
+        """Check if the sequence count can be changed with set_sequence or increase_sequence."""
+        return True
+
     @abc.abstractmethod
     def increase_sequence(self) -> None:
         """Increase the sequence count by 1."""

--- a/src/imap_mag/io/file/SequenceablePathHandler.py
+++ b/src/imap_mag/io/file/SequenceablePathHandler.py
@@ -14,6 +14,8 @@ class SequenceablePathHandler(IFilePathHandler):
     some sort of sequencing (e.g., versioning or part numbers).
     """
 
+    allow_overwrite: bool = False
+
     def supports_sequencing(self) -> bool:
         """Denotes whether this path handler supports sequence-like indexes."""
         return True

--- a/src/imap_mag/io/file/VersionedPathHandler.py
+++ b/src/imap_mag/io/file/VersionedPathHandler.py
@@ -33,6 +33,9 @@ class VersionedPathHandler(SequenceablePathHandler):
     def get_sequence(self) -> int:
         return self.version
 
+    def can_change_sequence(self) -> bool:
+        return self.supports_sequencing()
+
     def set_sequence(self, sequence: int) -> None:
         if not self.supports_sequencing():
             raise ValueError("This file does not support changing version/sequence. ")

--- a/src/prefect_server/pollHK.py
+++ b/src/prefect_server/pollHK.py
@@ -189,6 +189,8 @@ async def poll_hk_flow(
                 latest_timestamp=latest_ert_timestamp,
             )
         else:
-            logger.info(f"Database not updated for {progress_item_id}.")
+            logger.info(
+                f"Database workflow progress not updated for {progress_item_id}."
+            )
 
     logger.info("---------- Finished ----------")

--- a/src/prefect_server/pollHK.py
+++ b/src/prefect_server/pollHK.py
@@ -122,7 +122,7 @@ async def poll_hk_flow(
 
     if force_database_update and not force_ert:
         logger.warning(
-            "Database cannot be updated without forcing ERT. Database will not be updated."
+            "Workflow progress in database cannot be updated without forcing ERT. Progress downloading any files will not be recorded so these files may be redownloaded again later in scheduled jobs."
         )
 
     # If this is an automated flow run, use the database to figure out what to download,

--- a/src/prefect_server/pollScience.py
+++ b/src/prefect_server/pollScience.py
@@ -209,7 +209,7 @@ async def poll_science_flow(
 
     if force_database_update and not force_ingestion_date:
         logger.warning(
-            "Database cannot be updated without forcing ingestion date. Database will not be updated."
+            "Workflow progress in database cannot be updated without forcing ingestion date. Progress downloading any files will not be recorded so these files may be redownloaded again later in scheduled jobs."
         )
 
     # If this is an automated flow run, use the database to figure out what to download,

--- a/src/prefect_server/pollScience.py
+++ b/src/prefect_server/pollScience.py
@@ -101,9 +101,9 @@ def _download_batch_of_science(
             checked_timestamp=packet_start_timestamp,
             latest_timestamp=latest_ingestion_date,
         )
-        logger.info(f"Database updated for {progress_item_id}.")
+        logger.info(f"Database workflow progress updated for {progress_item_id}.")
     else:
-        logger.info(f"Database not updated for {progress_item_id}.")
+        logger.info(f"Database workflow progress not updated for {progress_item_id}.")
 
     return downloaded_science
 

--- a/src/prefect_server/pollScience.py
+++ b/src/prefect_server/pollScience.py
@@ -9,6 +9,7 @@ from pydantic import Field
 
 from imap_mag.cli.fetch.DownloadDateManager import DownloadDateManager
 from imap_mag.cli.fetch.science import fetch_science
+from imap_mag.config.DatastoreSaveOption import DatastoreSaveOption
 from imap_mag.config.FetchMode import FetchMode
 from imap_mag.db import Database, update_database_with_progress
 from imap_mag.io.file import SciencePathHandler
@@ -70,6 +71,7 @@ def _download_batch_of_science(
     packet_start_timestamp,
     batch_size,
     skip_items_count,
+    overwrite_option: DatastoreSaveOption = DatastoreSaveOption.FILE_OVERWRITES_BLOCKED,
 ) -> dict[Path, SciencePathHandler]:
     logger.info(
         f"Downloading batch of up to {batch_size} files for {progress_item_id} from {start_date} to {end_date}, skipping first {skip_items_count} items."
@@ -86,6 +88,7 @@ def _download_batch_of_science(
         fetch_mode=FetchMode.DownloadAndUpdateProgress,
         max_downloads=batch_size,
         skip_items_count=skip_items_count,
+        overwrite_option=overwrite_option,
     )
 
     # Update database with latest ingestion date as progress (for science)
@@ -174,6 +177,15 @@ async def poll_science_flow(
             }
         ),
     ] = False,
+    overwrite_option: Annotated[
+        DatastoreSaveOption,
+        Field(
+            json_schema_extra={
+                "title": "File overwrite option",
+                "description": "Whether to block or allow overwriting an existing datastore file that has the same version but different content. Default blocks overwrites and raises an error, which is the expected behaviour for SDC science files.",
+            }
+        ),
+    ] = DatastoreSaveOption.FILE_OVERWRITES_BLOCKED,
     # Used for automated testing only, to override the default datetime provider with a test one
     datetime_provider: Annotated[
         DatetimeProvider | None,
@@ -263,6 +275,7 @@ async def poll_science_flow(
                 packet_start_timestamp,
                 BATCH_SIZE,
                 len(downloaded_science),
+                overwrite_option,
             )
             if items:
                 downloaded_science.extend(items.keys())

--- a/src/prefect_server/pollScience.py
+++ b/src/prefect_server/pollScience.py
@@ -275,7 +275,7 @@ async def poll_science_flow(
                 packet_start_timestamp,
                 BATCH_SIZE,
                 len(downloaded_science),
-                overwrite_option,
+                overwrite_option=overwrite_option,
             )
             if items:
                 downloaded_science.extend(items.keys())

--- a/src/prefect_server/pollSpice.py
+++ b/src/prefect_server/pollSpice.py
@@ -224,7 +224,7 @@ async def poll_spice_flow(
             latest_timestamp=latest_ingestion_date,
         )
     else:
-        logger.info(f"Database not updated with progress for {progress_item_id}.")
+        logger.info(f"Database workflow progress not updated for {progress_item_id}.")
 
 
 # Enable quick local dev like `source .env && python -m src.prefect_server.spiceDownloadFlow` and "debug this file" in vscode

--- a/tests/integration/test_DBIndexedDatastoreFileManager.py
+++ b/tests/integration/test_DBIndexedDatastoreFileManager.py
@@ -325,7 +325,7 @@ def test_DBIndexedDatastoreFileManager_file_different_hash_already_exists_in_dat
     )
 
     assert (
-        "Existing versions [1, 2] found in database. Assigning next version 3 (max + 1)."
+        "Existing versions [1, 2] found in database. Assigning next available version 3 (max + 1)."
         in capture_cli_logs.text
     )
     assert f"Upserting {test_file} into database." in capture_cli_logs.text
@@ -475,7 +475,7 @@ def test_DBIndexedDatastoreFileManager_real_database_l0_hk_partitioned_file(
     )
 
     assert (
-        "Existing versions [1, 2] found in database. Assigning next version 3 (max + 1)."
+        "Existing versions [1, 2] found in database. Assigning next available version 3 (max + 1)."
         in capture_cli_logs.text
     )
     assert f"Upserting {test_file} into database." in capture_cli_logs.text
@@ -561,7 +561,7 @@ def test_DBIndexedDatastoreFileManager_real_database_l1_hk_versioned_file(
     )
 
     assert (
-        "Existing versions [1, 2] found in database. Assigning next version 3 (max + 1)."
+        "Existing versions [1, 2] found in database. Assigning next available version 3 (max + 1)."
         in capture_cli_logs.text
     )
     assert f"Upserting {test_file} into database." in capture_cli_logs.text

--- a/tests/integration/test_DBIndexedDatastoreFileManager.py
+++ b/tests/integration/test_DBIndexedDatastoreFileManager.py
@@ -95,6 +95,7 @@ def test_DBIndexedDatastoreFileManager_writes_to_database(
     mock_datastore_manager.add_file.side_effect = lambda *_: (
         create_test_file(test_file, "some content"),
         path_handler,
+        False,
     )
 
     mock_database.upsert_file.side_effect = lambda file: check_inserted_file(
@@ -102,7 +103,7 @@ def test_DBIndexedDatastoreFileManager_writes_to_database(
     )
 
     # Exercise.
-    (actual_file, actual_path_handler) = database_manager.add_file(
+    (actual_file, actual_path_handler, _) = database_manager.add_file(
         original_file, path_handler
     )
 
@@ -153,10 +154,11 @@ def test_DBIndexedDatastoreFileManager_same_file_already_exists_in_database(
     mock_datastore_manager.add_file.side_effect = lambda *_: (
         create_test_file(test_file, "some content"),
         path_handler,
+        False,
     )
 
     # Exercise.
-    (actual_file, actual_path_handler) = database_manager.add_file(
+    (actual_file, actual_path_handler, _) = database_manager.add_file(
         original_file, path_handler
     )
 
@@ -229,10 +231,11 @@ def test_DBIndexedDatastoreFileManager_same_file_already_exists_as_second_file_i
     mock_datastore_manager.add_file.side_effect = lambda *_: (
         create_test_file(test_file, "some content"),
         matched_path_handler,
+        False,
     )
 
     # Exercise.
-    (actual_file, actual_path_handler) = database_manager.add_file(
+    (actual_file, actual_path_handler, _) = database_manager.add_file(
         original_file, path_handler
     )
 
@@ -280,6 +283,7 @@ def test_DBIndexedDatastoreFileManager_file_different_hash_already_exists_in_dat
     mock_datastore_manager.add_file.side_effect = lambda *_: (
         create_test_file(test_file, "some content"),
         unique_path_handler,
+        False,
     )
 
     mock_database.get_files.side_effect = [
@@ -311,7 +315,7 @@ def test_DBIndexedDatastoreFileManager_file_different_hash_already_exists_in_dat
     )
 
     # Exercise.
-    (actual_file, actual_path_handler) = database_manager.add_file(
+    (actual_file, actual_path_handler, _) = database_manager.add_file(
         original_file, path_handler
     )
 
@@ -354,6 +358,7 @@ def test_DBIndexedDatastoreFileManager_errors_when_destination_file_is_not_found
     mock_datastore_manager.add_file.side_effect = lambda *_: (
         test_file,
         path_handler,
+        False,
     )
 
     # Exercise and verify.
@@ -383,6 +388,7 @@ def test_DBIndexedDatastoreFileManager_errors_database_error(
     mock_datastore_manager.add_file.side_effect = lambda *_: (
         create_test_file(test_file, "some content"),
         path_handler,
+        False,
     )
 
     mock_database.upsert_file.side_effect = ArithmeticError("Database error")
@@ -426,6 +432,7 @@ def test_DBIndexedDatastoreFileManager_real_database_l0_hk_partitioned_file(
     mock_datastore_manager.add_file.side_effect = lambda *_: (
         create_test_file(test_file, "some content"),
         unique_path_handler,
+        False,
     )
 
     test_database.upsert_files(
@@ -458,7 +465,7 @@ def test_DBIndexedDatastoreFileManager_real_database_l0_hk_partitioned_file(
     )
 
     # Exercise.
-    (actual_file, actual_path_handler) = database_manager.add_file(
+    (actual_file, actual_path_handler, _) = database_manager.add_file(
         original_file, path_handler
     )
 
@@ -511,6 +518,7 @@ def test_DBIndexedDatastoreFileManager_real_database_l1_hk_versioned_file(
     mock_datastore_manager.add_file.side_effect = lambda *_: (
         create_test_file(test_file, "some content"),
         unique_path_handler,
+        False,
     )
 
     test_database.upsert_files(
@@ -543,7 +551,7 @@ def test_DBIndexedDatastoreFileManager_real_database_l1_hk_versioned_file(
     )
 
     # Exercise.
-    (actual_file, actual_path_handler) = database_manager.add_file(
+    (actual_file, actual_path_handler, _) = database_manager.add_file(
         original_file, path_handler
     )
 
@@ -595,6 +603,7 @@ def test_DBIndexedDatastoreFileManager_add_ancillary_files_uses_correct_dates(
     mock_datastore_manager.add_file.side_effect = lambda *_: (
         create_test_file(test_file, "some content"),
         unique_path_handler,
+        False,
     )
 
     # Exercise
@@ -718,10 +727,11 @@ def test_calibration_layer_db_dedup_identical_content_reuses_v001(
             ),
         ),
         path_handler,
+        False,
     )
 
     # Exercise
-    (_, _) = database_manager.add_file(work_json, path_handler)
+    database_manager.add_file(work_json, path_handler)
 
     # Verify: deduplication happened — no new DB record
     assert path_handler.version == 1
@@ -812,10 +822,11 @@ def test_calibration_layer_db_dedup_multiple_records_same_hash_handled_gracefull
             ),
         ),
         path_handler,
+        False,
     )
 
     # Must not raise AssertionError
-    (_, _) = database_manager.add_file(work_json, path_handler)
+    database_manager.add_file(work_json, path_handler)
 
     # Should reuse v002.0001 (matching version_major=2), no new record
     assert path_handler.version == 1
@@ -878,11 +889,11 @@ def test_calibration_layer_db_different_content_creates_v002_with_correct_meta(
 
     def capture_add_file(
         source: Path, handler
-    ) -> tuple[Path, CalibrationLayerPathHandler]:
+    ) -> tuple[Path, CalibrationLayerPathHandler, bool]:
         captured_contents.append(json.loads(source.read_text()))
         dest = Path(tempfile.gettempdir()) / f"layer_v{handler.version:03d}.json"
         dest.write_bytes(source.read_bytes())
-        return dest, handler
+        return dest, handler, False
 
     mock_datastore_manager.add_file.side_effect = capture_add_file
 
@@ -985,6 +996,7 @@ def test_calibration_layer_db_deleted_version_not_compared_or_blocking(
             ),
         ),
         path_handler,
+        False,
     )
 
     # Exercise
@@ -1029,10 +1041,10 @@ def test_adding_file_to_real_postgres_sets_last_modified_date_in_database(
 
     modified_timestamp = datetime(2025, 5, 3, 12, 34, 56).timestamp()
 
-    def add_file_side_effect(*_) -> tuple[Path, HKDecodedPathHandler]:
+    def add_file_side_effect(*_) -> tuple[Path, HKDecodedPathHandler, bool]:
         created_file = create_test_file(test_file, "some content")
         os.utime(created_file, (modified_timestamp, modified_timestamp))
-        return created_file, path_handler
+        return created_file, path_handler, False
 
     mock_datastore_manager.add_file.side_effect = add_file_side_effect
 
@@ -1091,7 +1103,7 @@ def test_DBIndexedDatastoreFileManager_add_file_with_deleted_file_to_real_postgr
     test_database.upsert_files([existing_file_record])
 
     # Exercise.
-    (actual_file, _) = database_manager.add_file(new_file, path_handler)
+    (actual_file, _, _) = database_manager.add_file(new_file, path_handler)
 
     # assert only one file record exists and it is not deleted, with last modified updated to now
     database_files = test_database.get_files()
@@ -1147,7 +1159,7 @@ def test_DBIndexedDatastoreFileManager_add_same_file_with_existing_file_to_real_
     test_database.upsert_files([existing_file_record])
 
     # Exercise.
-    (actual_file, _) = database_manager.add_file(new_file, path_handler)
+    (actual_file, _, _) = database_manager.add_file(new_file, path_handler)
 
     # assert only one file record exists and it is not deleted, with last modified updated to now
     database_files = test_database.get_files()
@@ -1189,6 +1201,7 @@ def test_DBIndexedDatastoreFileManager_science_file_version_major_stored_in_db(
     mock_datastore_manager.add_file.side_effect = lambda *_: (
         create_test_file(test_file, "science content vmaj"),
         path_handler,
+        False,
     )
     mock_database.get_files.return_value = []
 
@@ -1260,6 +1273,7 @@ def test_DBIndexedDatastoreFileManager_get_next_available_version_major_scans_mi
     mock_datastore_manager.add_file.side_effect = lambda *_: (
         create_test_file(test_file, "new science content"),
         path_handler,
+        False,
     )
 
     captured_files: list[File] = []
@@ -1321,6 +1335,7 @@ def test_DBIndexedDatastoreFileManager_get_next_available_version_uses_max_plus_
     mock_datastore_manager.add_file.side_effect = lambda *_: (
         create_test_file(test_file, "new science content"),
         path_handler,
+        False,
     )
 
     captured_files: list[File] = []

--- a/tests/integration/test_pollHK.py
+++ b/tests/integration/test_pollHK.py
@@ -369,7 +369,7 @@ async def test_poll_hk_specify_packets_and_start_end_dates(
 
     if force_database_update:
         assert (
-            "Database cannot be updated without forcing ERT. Database will not be updated."
+            "Workflow progress in database cannot be updated without forcing ERT. Progress downloading any files will not be recorded so these files may be redownloaded again later in scheduled jobs."
             in capture_cli_logs.text
         )
 

--- a/tests/integration/test_pollScience.py
+++ b/tests/integration/test_pollScience.py
@@ -310,7 +310,7 @@ async def test_poll_science_specify_packets_and_start_end_dates(
 
     if force_database_update:
         assert (
-            "Database cannot be updated without forcing ingestion date. Database will not be updated."
+            "Workflow progress in database cannot be updated without forcing ingestion date. Progress downloading any files will not be recorded so these files may be redownloaded again later in scheduled jobs."
             in capture_cli_logs.text
         )
 

--- a/tests/integration/test_pollScience.py
+++ b/tests/integration/test_pollScience.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+from imap_mag.config import DatastoreSaveOption
 from imap_mag.config.AppSettings import AppSettings
 from imap_mag.download.FetchScience import FetchScience
 from imap_mag.util import Environment, ScienceMode
@@ -35,9 +36,11 @@ def define_available_data_sdc_mappings(
     end_date: datetime,
     ingestion_timestamp: datetime,
     is_ingestion_date: bool = False,
+    content: str = "some super scientific content",
+    version: str = "v000",
 ):
     science_file = create_test_file(
-        Path(tempfile.gettempdir()) / "science.cdf", "some super scientific content"
+        Path(tempfile.gettempdir()) / "science.cdf", content
     )
 
     mode_str = mode.short_name
@@ -48,13 +51,13 @@ def define_available_data_sdc_mappings(
 
     query_response: list[dict[str, str]] = [
         {
-            "file_path": f"imap/mag/l1c/{start_date.year}/{start_date.month:02}/imap_mag_l1c_{mode_str}-magi_{start_date_str}_v000.cdf",
+            "file_path": f"imap/mag/l1c/{start_date.year}/{start_date.month:02}/imap_mag_l1c_{mode_str}-magi_{start_date_str}_{version}.cdf",
             "instrument": "mag",
             "data_level": "l1c",
             "descriptor": f"{mode_str}-magi",
             "start_date": start_date_str,
             "repointing": None,
-            "version": "v000",
+            "version": version,
             "extension": "cdf",
             "ingestion_date": ingestion_timestamp.strftime("%Y%m%d %H:%M:%S"),
         }
@@ -65,7 +68,7 @@ def define_available_data_sdc_mappings(
         priority=1,
     )
     wiremock_manager.add_file_mapping(
-        f"/download/imap/mag/l1c/{start_date.year}/{start_date.month:02}/imap_mag_l1c_{mode_str}-magi_{start_date_str}_v000.cdf",
+        f"/download/imap/mag/l1c/{start_date.year}/{start_date.month:02}/imap_mag_l1c_{mode_str}-magi_{start_date_str}_{version}.cdf",
         science_file,
     )
 
@@ -130,15 +133,24 @@ def verify_available_modes(
     check_file_existence(available_modes, actual_timestamp)
 
 
-def check_file_existence(modes_to_check: list[ScienceMode], actual_timestamp: datetime):
+def check_file_existence(
+    modes_to_check: list[ScienceMode],
+    actual_timestamp: datetime,
+    content_to_verify: str | None = None,
+    version: str = "v000",
+):
     datastore = AppSettings().data_store
     for mode in modes_to_check:
         data_folder = os.path.join(
             datastore, "science/mag/l1c", actual_timestamp.strftime("%Y/%m")
         )
-        cdf_file = f"imap_mag_l1c_{mode.short_name}-magi_{actual_timestamp.strftime('%Y%m%d')}_v000.cdf"
+        cdf_file = f"imap_mag_l1c_{mode.short_name}-magi_{actual_timestamp.strftime('%Y%m%d')}_{version}.cdf"
 
-        assert os.path.exists(os.path.join(data_folder, cdf_file))
+        file_path = os.path.join(data_folder, cdf_file)
+        assert os.path.exists(file_path)
+        if content_to_verify is not None:
+            with open(file_path) as f:
+                assert f.read() == content_to_verify
 
 
 @pytest.mark.skipif(
@@ -416,3 +428,98 @@ async def test_database_progress_table_not_modified_if_poll_science_fails(
 
     # Verify.
     verify_not_requested_modes(test_database, [m for m in ScienceMode])
+
+
+@pytest.mark.skipif(
+    os.getenv("GITHUB_ACTIONS") and os.getenv("RUNNER_OS") == "Windows",
+    reason="Wiremock test containers will not work on Windows Github Runner",
+)
+@pytest.mark.asyncio
+async def test_poll_science_refuses_overwrites_with_different_files_unless_explicitly_allowed(
+    wiremock_manager,
+    test_database,  # noqa: F811
+    prefect_test_fixture,  # noqa: F811
+    capture_cli_logs,
+    clean_datastore,
+    dynamic_work_folder,
+):
+    # Set up.
+    start_date = datetime(2025, 4, 1)
+    end_date = datetime(2025, 4, 2)
+    version = "v003"
+    ingestion_timestamp = datetime(2025, 4, 2, 13, 37, 9)
+
+    wiremock_manager.reset()
+
+    # Some data is available for the requested dates for Burst mode.
+    define_available_data_sdc_mappings(
+        wiremock_manager,
+        ScienceMode.Burst,
+        start_date,
+        end_date,
+        ingestion_timestamp,
+        is_ingestion_date=False,
+        version=version,
+    )
+
+    # No data is available for any other date/packet.
+    define_unavailable_data_sdc_mappings(wiremock_manager)
+
+    # Exercise.
+    with Environment(
+        IMAP_DATA_ACCESS_URL=wiremock_manager.get_url(),
+        IMAP_API_KEY="12345",
+    ):
+        await poll_science_flow(
+            modes=[ScienceMode.Burst],
+            start_date=start_date,
+            end_date=end_date,
+            datetime_provider=DatetimeProvider(fixed_now=NOW),
+        )
+        check_file_existence(
+            [ScienceMode.Burst],
+            start_date,
+            "some super scientific content",
+            version=version,
+        )
+        # Some data is available for the requested dates for Burst mode.
+        define_available_data_sdc_mappings(
+            wiremock_manager,
+            ScienceMode.Burst,
+            start_date,
+            end_date,
+            ingestion_timestamp,
+            is_ingestion_date=False,
+            content="some different super scientific content",
+            version=version,
+        )
+        # force redownload of the same file with different content
+        # throws because of overwrite
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                "Cannot proceed with adding file imap_mag_l1c_burst-magi_20250401_v003.cdf.Existing version(s) [3] found in database with different content which cannot be overwritten without allow_overwrite option"
+            ),
+        ):
+            await poll_science_flow(
+                modes=[ScienceMode.Burst],
+                start_date=start_date,
+                end_date=end_date,
+                datetime_provider=DatetimeProvider(fixed_now=NOW),
+            )
+
+        # does not throw because overwrite is allowed
+        await poll_science_flow(
+            modes=[ScienceMode.Burst],
+            start_date=start_date,
+            end_date=end_date,
+            datetime_provider=DatetimeProvider(fixed_now=NOW),
+            overwrite_option=DatastoreSaveOption.FILE_OVERWRITES_ALLOWED,
+        )
+
+        check_file_existence(
+            [ScienceMode.Burst],
+            start_date,
+            "some different super scientific content",
+            version=version,
+        )

--- a/tests/unit/test_DatastoreFileManager.py
+++ b/tests/unit/test_DatastoreFileManager.py
@@ -250,7 +250,7 @@ def test_copy_file_same_origin_destination(temp_folder_path, caplog):
     original_mod_time = original_file.stat().st_mtime
 
     # Exercise.
-    (new_file, _) = manager.add_file(
+    (new_file, _, _) = manager.add_file(
         original_file,
         CustomPathHandler(
             folder=temp_folder_path.as_posix(),
@@ -307,7 +307,7 @@ def test_calibration_layer_identical_content_deduplicates_to_existing_version(
         descriptor="quality-norm", content_date=date, version=1, version_major=1
     )
 
-    (result_path, _) = manager.add_file(work_json, handler)
+    (result_path, _, _) = manager.add_file(work_json, handler)
 
     assert result_path.name == "imap_mag_quality-norm-layer_20260116_v001.0001.json"
     assert handler.version == 1
@@ -339,7 +339,7 @@ def test_calibration_layer_different_content_bumps_to_v002(
         descriptor="quality-norm", content_date=date, version=1, version_major=1
     )
 
-    (result_path, _) = manager.add_file(work_json, handler)
+    (result_path, _, _) = manager.add_file(work_json, handler)
 
     assert result_path.name == "imap_mag_quality-norm-layer_20260116_v001.0002.json"
     assert handler.version == 2
@@ -372,10 +372,11 @@ def test_calibration_layer_csv_saved_at_matching_version(temp_folder_path):
     manager.add_file(work_json, json_handler)
 
     csv_handler = json_handler.get_equivalent_data_handler()  # version now 2
-    (csv_result, _) = manager.add_file(work_csv, csv_handler)
+    (csv_result, _, overwrite) = manager.add_file(work_csv, csv_handler)
 
     assert csv_result.name == "imap_mag_quality-norm-layer-data_20260116_v001.0002.csv"
     assert csv_result.read_bytes() == work_csv.read_bytes()
+    assert overwrite is False
 
 
 def test_allow_overwrite_replaces_same_version(temp_folder_path):
@@ -402,7 +403,7 @@ def test_allow_overwrite_replaces_same_version(temp_folder_path):
     )
     handler.versioning_mode = handler.VersionMode.USER_OVERRIDE
 
-    (result_path, _) = manager.add_file(work_json, handler)
+    (result_path, _, overwrite) = manager.add_file(work_json, handler)
 
     assert result_path.name == "imap_mag_quality-norm-layer_20260116_v001.0003.json"
     # Content replaced — hash differs because the seed (and thus timestamp+hash) changed.
@@ -412,6 +413,7 @@ def test_allow_overwrite_replaces_same_version(temp_folder_path):
     assert not (
         store_dir / "imap_mag_quality-norm-layer_20260116_v001.0004.json"
     ).exists()
+    assert overwrite is True
 
 
 # ── Disk space threshold checks ───────────────────────────────────────────────
@@ -465,7 +467,7 @@ def test_add_file_allowed_when_disk_usage_below_threshold(temp_folder_path):
     original_file = create_test_file(Path(f"{temp_folder_path}/source.txt"))
 
     with patch("shutil.disk_usage", return_value=_disk_usage_at(0.94)):
-        (destination, _) = manager.add_file(
+        (destination, _, _) = manager.add_file(
             original_file,
             HKDecodedPathHandler(
                 descriptor="pwr",

--- a/tests/unit/test_DownloadSpinTableFilesStage.py
+++ b/tests/unit/test_DownloadSpinTableFilesStage.py
@@ -173,7 +173,7 @@ class TestDownloadSpinTableFilesStageProcess:
         mock_handler.add_metadata = MagicMock()
 
         mock_manager = MagicMock()
-        mock_manager.add_file.return_value = (csv_file, mock_handler)
+        mock_manager.add_file.return_value = (csv_file, mock_handler, False)
 
         stage = DownloadSpinTableFilesStage(
             client=mock_client, settings=mock_settings, database=None

--- a/tests/unit/test_fetchScience_cli.py
+++ b/tests/unit/test_fetchScience_cli.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from imap_db.model import File
 from imap_mag.cli.fetch.science import fetch_science
 from imap_mag.config import AppSettings, DatastoreSaveOption, FetchMode
 from imap_mag.io import DatastoreFileManager, DBIndexedDatastoreFileManager
@@ -250,12 +251,17 @@ class TestFetchScienceOverwriteOption:
         # The path must contain the expected folder structure so the DB filter passes.
         content_hash = hashlib.md5(new_content).hexdigest()
         folder_structure = handler.get_folder_structure()
-        db_record_at_wrong_version = MagicMock(
-            hash=content_hash,
+        db_record_at_wrong_version = File(
+            name="imap_mag_l1c_norm-magi_20250502_v001.0099.cdf",
+            path=f"{folder_structure}/imap_mag_l1c_norm-magi_20250502_v001.0099.cdf",
+            descriptor="norm-magi",
             version=99,
             version_major=self._VERSION_MAJOR,
-            path=f"{folder_structure}/imap_mag_l1c_norm-magi_20250502_v001.0099.cdf",
+            hash=content_hash,
+            size=len(new_content),
+            content_date=self._DATE,
             deletion_date=None,
+            software_version="0.0.0",
         )
 
         mock_fetch = MagicMock()

--- a/tests/unit/test_fetchScience_cli.py
+++ b/tests/unit/test_fetchScience_cli.py
@@ -1,9 +1,15 @@
 """Tests for fetch science CLI command."""
 
 from datetime import datetime
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from imap_mag.cli.fetch.science import fetch_science
+from imap_mag.config import AppSettings, DatastoreSaveOption, FetchMode
+from imap_mag.io import DatastoreFileManager, DBIndexedDatastoreFileManager
+from imap_mag.io.file import SciencePathHandler
 
 
 class TestFetchScience:
@@ -28,3 +34,190 @@ class TestFetchScience:
             )
 
         assert result == {}
+
+
+class TestFetchScienceOverwriteOption:
+    """Tests for DatastoreSaveOption in fetch_science covering no-DB and DB cases."""
+
+    _LEVEL = "l1c"
+    _DESCRIPTOR = "norm-magi"
+    _DATE = datetime(2025, 5, 2)
+    _VERSION = 0
+    _VERSION_MAJOR = 1
+
+    def _create_existing_file_in_datastore(
+        self, datastore: Path, content: str = "original content"
+    ) -> SciencePathHandler:
+        """Place a science file in the datastore directory and return its handler."""
+        handler = SciencePathHandler(
+            level=self._LEVEL,
+            descriptor=self._DESCRIPTOR,
+            content_date=self._DATE,
+            version=self._VERSION,
+            version_major=self._VERSION_MAJOR,
+            has_major_version=True,
+            extension="cdf",
+        )
+        folder = datastore / handler.get_folder_structure()
+        folder.mkdir(parents=True, exist_ok=True)
+        (folder / handler.get_filename()).write_text(content)
+        return handler
+
+    def _make_downloaded_handler(self) -> SciencePathHandler:
+        """Return a locked handler as FetchScience would produce."""
+        return SciencePathHandler(
+            level=self._LEVEL,
+            descriptor=self._DESCRIPTOR,
+            content_date=self._DATE,
+            version=self._VERSION,
+            version_major=self._VERSION_MAJOR,
+            has_major_version=True,
+            extension="cdf",
+            version_is_locked=True,
+        )
+
+    def _make_downloaded_file(
+        self, work_folder: Path, content: str = "updated content"
+    ) -> Path:
+        """Create a temporary file that represents a freshly downloaded science file."""
+        downloaded = work_folder / "downloaded_science.cdf"
+        downloaded.write_text(content)
+        return downloaded
+
+    def _db_backed_manager(
+        self, settings: AppSettings
+    ) -> DBIndexedDatastoreFileManager:
+        """Return a DBIndexedDatastoreFileManager using a mock database."""
+        mock_db = MagicMock()
+        mock_db.get_files.return_value = []
+        real_dsm = DatastoreFileManager(settings)
+        return DBIndexedDatastoreFileManager(
+            real_dsm, database=mock_db, settings=settings
+        )
+
+    # ── No-database (DownloadOnly) tests ────────────────────────────────────
+
+    def test_blocked_raises_when_same_version_different_content_no_db(
+        self, dynamic_work_folder, clean_datastore
+    ):
+        """FILE_OVERWRITES_BLOCKED raises ValueError when the same-version file has different content (no DB)."""
+        self._create_existing_file_in_datastore(clean_datastore)
+        downloaded_file = self._make_downloaded_file(dynamic_work_folder)
+        handler = self._make_downloaded_handler()
+
+        mock_fetch = MagicMock()
+        mock_fetch.download_science.return_value = {downloaded_file: handler}
+
+        with (
+            patch("imap_mag.cli.fetch.science.SDCDataAccess"),
+            patch("imap_mag.cli.fetch.science.FetchScience", return_value=mock_fetch),
+            patch("imap_mag.cli.fetch.science.initialiseLoggingForCommand"),
+            pytest.raises(ValueError, match="cannot be changed"),
+        ):
+            fetch_science(
+                start_date=self._DATE,
+                end_date=self._DATE,
+                fetch_mode=FetchMode.DownloadOnly,
+                overwrite_option=DatastoreSaveOption.FILE_OVERWRITES_BLOCKED,
+            )
+
+    def test_allowed_overwrites_same_version_different_content_no_db(
+        self, dynamic_work_folder, clean_datastore
+    ):
+        """FILE_OVERWRITES_ALLOWED silently replaces the file at the same version (no DB)."""
+        self._create_existing_file_in_datastore(
+            clean_datastore, content="original content"
+        )
+        downloaded_file = self._make_downloaded_file(
+            dynamic_work_folder, content="updated content"
+        )
+        handler = self._make_downloaded_handler()
+
+        mock_fetch = MagicMock()
+        mock_fetch.download_science.return_value = {downloaded_file: handler}
+
+        with (
+            patch("imap_mag.cli.fetch.science.SDCDataAccess"),
+            patch("imap_mag.cli.fetch.science.FetchScience", return_value=mock_fetch),
+            patch("imap_mag.cli.fetch.science.initialiseLoggingForCommand"),
+        ):
+            result = fetch_science(
+                start_date=self._DATE,
+                end_date=self._DATE,
+                fetch_mode=FetchMode.DownloadOnly,
+                overwrite_option=DatastoreSaveOption.FILE_OVERWRITES_ALLOWED,
+            )
+
+        assert len(result) == 1
+        output_file = next(iter(result.keys()))
+        assert output_file.read_text() == "updated content"
+        assert result[output_file].version == self._VERSION
+
+    # ── Database-used (DownloadAndUpdateProgress) tests ─────────────────────
+
+    def test_blocked_raises_when_same_version_different_content_with_db(
+        self, dynamic_work_folder, clean_datastore
+    ):
+        """FILE_OVERWRITES_BLOCKED raises ValueError when the same-version file has different content (with DB)."""
+        self._create_existing_file_in_datastore(clean_datastore)
+        downloaded_file = self._make_downloaded_file(dynamic_work_folder)
+        handler = self._make_downloaded_handler()
+
+        mock_fetch = MagicMock()
+        mock_fetch.download_science.return_value = {downloaded_file: handler}
+
+        with (
+            patch("imap_mag.cli.fetch.science.SDCDataAccess"),
+            patch("imap_mag.cli.fetch.science.FetchScience", return_value=mock_fetch),
+            patch("imap_mag.cli.fetch.science.initialiseLoggingForCommand"),
+            patch(
+                "imap_mag.cli.fetch.science.DatastoreFileManager.CreateByMode",
+                return_value=self._db_backed_manager(AppSettings()),  # type: ignore
+            ),
+            pytest.raises(ValueError, match="cannot be changed"),
+        ):
+            fetch_science(
+                start_date=self._DATE,
+                end_date=self._DATE,
+                fetch_mode=FetchMode.DownloadAndUpdateProgress,
+                overwrite_option=DatastoreSaveOption.FILE_OVERWRITES_BLOCKED,
+            )
+
+    def test_allowed_overwrites_same_version_different_content_with_db(
+        self, dynamic_work_folder, clean_datastore
+    ):
+        """FILE_OVERWRITES_ALLOWED replaces the file and upserts the DB record (with DB)."""
+        self._create_existing_file_in_datastore(
+            clean_datastore, content="original content"
+        )
+        downloaded_file = self._make_downloaded_file(
+            dynamic_work_folder, content="updated content"
+        )
+        handler = self._make_downloaded_handler()
+
+        mock_fetch = MagicMock()
+        mock_fetch.download_science.return_value = {downloaded_file: handler}
+
+        db_manager = self._db_backed_manager(AppSettings())  # type: ignore
+
+        with (
+            patch("imap_mag.cli.fetch.science.SDCDataAccess"),
+            patch("imap_mag.cli.fetch.science.FetchScience", return_value=mock_fetch),
+            patch("imap_mag.cli.fetch.science.initialiseLoggingForCommand"),
+            patch(
+                "imap_mag.cli.fetch.science.DatastoreFileManager.CreateByMode",
+                return_value=db_manager,
+            ),
+        ):
+            result = fetch_science(
+                start_date=self._DATE,
+                end_date=self._DATE,
+                fetch_mode=FetchMode.DownloadAndUpdateProgress,
+                overwrite_option=DatastoreSaveOption.FILE_OVERWRITES_ALLOWED,
+            )
+
+        assert len(result) == 1
+        output_file = next(iter(result.keys()))
+        assert output_file.read_text() == "updated content"
+        assert result[output_file].version == self._VERSION
+        db_manager._DBIndexedDatastoreFileManager__database.upsert_file.assert_called_once()

--- a/tests/unit/test_fetchScience_cli.py
+++ b/tests/unit/test_fetchScience_cli.py
@@ -229,14 +229,14 @@ class TestFetchScienceOverwriteOption:
         assert result[output_file].version_is_locked is True
         db_manager._DBIndexedDatastoreFileManager__database.upsert_file.assert_called_once()
 
-    def test_allowed_with_db_rejects_version_reassignment_even_for_same_hash(
+    def test_allowed_with_db_hash_match_at_different_version_saves_at_downloaded_version(
         self, dynamic_work_folder, clean_datastore
     ):
-        """FILE_OVERWRITES_ALLOWED + version_is_locked blocks silent version reassignment.
+        """FILE_OVERWRITES_ALLOWED saves at the SDC-assigned version even when the DB
+        holds the same content at a different version.
 
-        If the DB already holds the same content (same hash) at a *different* version,
-        the handler's version_is_locked=True must prevent set_sequence() from silently
-        adopting that version — the SDC-assigned version is authoritative.
+        The same-content-different-version DB record is a pre-existing anomaly that
+        should generate a warning but must not redirect the save to a different version.
         """
         self._create_existing_file_in_datastore(
             clean_datastore, content="original content"
@@ -247,11 +247,10 @@ class TestFetchScienceOverwriteOption:
         )
         handler = self._make_downloaded_handler()
 
-        # DB has the same hash as the new file but at a DIFFERENT version (99 vs 0).
-        # The path must contain the expected folder structure so the DB filter passes.
+        # DB already holds the same content hash but at version 99, not the downloaded version 0.
         content_hash = hashlib.md5(new_content).hexdigest()
         folder_structure = handler.get_folder_structure()
-        db_record_at_wrong_version = File(
+        db_record_at_different_version = File(
             name="imap_mag_l1c_norm-magi_20250502_v001.0099.cdf",
             path=f"{folder_structure}/imap_mag_l1c_norm-magi_20250502_v001.0099.cdf",
             descriptor="norm-magi",
@@ -268,7 +267,7 @@ class TestFetchScienceOverwriteOption:
         mock_fetch.download_science.return_value = {downloaded_file: handler}
 
         mock_db = MagicMock()
-        mock_db.get_files.return_value = [db_record_at_wrong_version]
+        mock_db.get_files.return_value = [db_record_at_different_version]
         real_dsm = DatastoreFileManager(AppSettings())  # type: ignore
         db_manager = DBIndexedDatastoreFileManager(
             real_dsm,
@@ -284,11 +283,18 @@ class TestFetchScienceOverwriteOption:
                 "imap_mag.cli.fetch.science.DatastoreFileManager.CreateByMode",
                 return_value=db_manager,
             ),
-            pytest.raises(ValueError, match="cannot be changed"),
         ):
-            fetch_science(
+            result = fetch_science(
                 start_date=self._DATE,
                 end_date=self._DATE,
                 fetch_mode=FetchMode.DownloadAndUpdateProgress,
                 overwrite_option=DatastoreSaveOption.FILE_OVERWRITES_ALLOWED,
             )
+
+        assert len(result) == 1
+        output_file = next(iter(result.keys()))
+        assert output_file.read_text() == "updated content"
+        # Version stays at the SDC-assigned value, not the DB record's version 99.
+        assert result[output_file].version == self._VERSION
+        assert result[output_file].version_is_locked is True
+        mock_db.upsert_file.assert_called_once()

--- a/tests/unit/test_fetchScience_cli.py
+++ b/tests/unit/test_fetchScience_cli.py
@@ -1,5 +1,6 @@
 """Tests for fetch science CLI command."""
 
+import hashlib
 from datetime import datetime
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -152,6 +153,9 @@ class TestFetchScienceOverwriteOption:
         output_file = next(iter(result.keys()))
         assert output_file.read_text() == "updated content"
         assert result[output_file].version == self._VERSION
+        # version_is_locked must remain True even in ALLOWED mode — the version
+        # number is authoritative from SDC and must never change.
+        assert result[output_file].version_is_locked is True
 
     # ── Database-used (DownloadAndUpdateProgress) tests ─────────────────────
 
@@ -220,4 +224,65 @@ class TestFetchScienceOverwriteOption:
         output_file = next(iter(result.keys()))
         assert output_file.read_text() == "updated content"
         assert result[output_file].version == self._VERSION
+        # version_is_locked must remain True even in ALLOWED mode.
+        assert result[output_file].version_is_locked is True
         db_manager._DBIndexedDatastoreFileManager__database.upsert_file.assert_called_once()
+
+    def test_allowed_with_db_rejects_version_reassignment_even_for_same_hash(
+        self, dynamic_work_folder, clean_datastore
+    ):
+        """FILE_OVERWRITES_ALLOWED + version_is_locked blocks silent version reassignment.
+
+        If the DB already holds the same content (same hash) at a *different* version,
+        the handler's version_is_locked=True must prevent set_sequence() from silently
+        adopting that version — the SDC-assigned version is authoritative.
+        """
+        self._create_existing_file_in_datastore(
+            clean_datastore, content="original content"
+        )
+        new_content = b"updated content"
+        downloaded_file = self._make_downloaded_file(
+            dynamic_work_folder, content=new_content.decode()
+        )
+        handler = self._make_downloaded_handler()
+
+        # DB has the same hash as the new file but at a DIFFERENT version (99 vs 0).
+        # The path must contain the expected folder structure so the DB filter passes.
+        content_hash = hashlib.md5(new_content).hexdigest()
+        folder_structure = handler.get_folder_structure()
+        db_record_at_wrong_version = MagicMock(
+            hash=content_hash,
+            version=99,
+            version_major=self._VERSION_MAJOR,
+            path=f"{folder_structure}/imap_mag_l1c_norm-magi_20250502_v001.0099.cdf",
+            deletion_date=None,
+        )
+
+        mock_fetch = MagicMock()
+        mock_fetch.download_science.return_value = {downloaded_file: handler}
+
+        mock_db = MagicMock()
+        mock_db.get_files.return_value = [db_record_at_wrong_version]
+        real_dsm = DatastoreFileManager(AppSettings())  # type: ignore
+        db_manager = DBIndexedDatastoreFileManager(
+            real_dsm,
+            database=mock_db,
+            settings=AppSettings(),  # type: ignore
+        )
+
+        with (
+            patch("imap_mag.cli.fetch.science.SDCDataAccess"),
+            patch("imap_mag.cli.fetch.science.FetchScience", return_value=mock_fetch),
+            patch("imap_mag.cli.fetch.science.initialiseLoggingForCommand"),
+            patch(
+                "imap_mag.cli.fetch.science.DatastoreFileManager.CreateByMode",
+                return_value=db_manager,
+            ),
+            pytest.raises(ValueError, match="cannot be changed"),
+        ):
+            fetch_science(
+                start_date=self._DATE,
+                end_date=self._DATE,
+                fetch_mode=FetchMode.DownloadAndUpdateProgress,
+                overwrite_option=DatastoreSaveOption.FILE_OVERWRITES_ALLOWED,
+            )

--- a/tests/unit/test_fetchScience_cli.py
+++ b/tests/unit/test_fetchScience_cli.py
@@ -88,14 +88,14 @@ class TestFetchScienceOverwriteOption:
 
     def _db_backed_manager(
         self, settings: AppSettings
-    ) -> DBIndexedDatastoreFileManager:
-        """Return a DBIndexedDatastoreFileManager using a mock database."""
+    ) -> tuple[DBIndexedDatastoreFileManager, MagicMock]:
+        """Return a DBIndexedDatastoreFileManager and its mock database."""
         mock_db = MagicMock()
         mock_db.get_files.return_value = []
         real_dsm = DatastoreFileManager(settings)
         return DBIndexedDatastoreFileManager(
             real_dsm, database=mock_db, settings=settings
-        )
+        ), mock_db
 
     # ── No-database (DownloadOnly) tests ────────────────────────────────────
 
@@ -177,7 +177,7 @@ class TestFetchScienceOverwriteOption:
             patch("imap_mag.cli.fetch.science.initialiseLoggingForCommand"),
             patch(
                 "imap_mag.cli.fetch.science.DatastoreFileManager.CreateByMode",
-                return_value=self._db_backed_manager(AppSettings()),  # type: ignore
+                return_value=self._db_backed_manager(AppSettings())[0],  # type: ignore
             ),
             pytest.raises(ValueError, match="cannot be changed"),
         ):
@@ -203,7 +203,7 @@ class TestFetchScienceOverwriteOption:
         mock_fetch = MagicMock()
         mock_fetch.download_science.return_value = {downloaded_file: handler}
 
-        db_manager = self._db_backed_manager(AppSettings())  # type: ignore
+        db_manager, mock_db = self._db_backed_manager(AppSettings())  # type: ignore
 
         with (
             patch("imap_mag.cli.fetch.science.SDCDataAccess"),
@@ -227,7 +227,7 @@ class TestFetchScienceOverwriteOption:
         assert result[output_file].version == self._VERSION
         # version_is_locked must remain True even in ALLOWED mode.
         assert result[output_file].version_is_locked is True
-        db_manager._DBIndexedDatastoreFileManager__database.upsert_file.assert_called_once()
+        mock_db.upsert_file.assert_called_once()
 
     def test_allowed_with_db_hash_match_at_different_version_saves_at_downloaded_version(
         self, dynamic_work_folder, clean_datastore

--- a/tests/unit/test_pollScience.py
+++ b/tests/unit/test_pollScience.py
@@ -445,14 +445,7 @@ class TestPollScienceFlowOverwriteOption:
             )
 
         _, kwargs = mock_batch.call_args
-        assert kwargs.get(
-            "overwrite_option", ...
-        ) == DatastoreSaveOption.FILE_OVERWRITES_BLOCKED or (
-            # positional call: overwrite_option is the last positional arg (index 14)
-            mock_batch.call_args.args
-            and mock_batch.call_args.args[-1]
-            == DatastoreSaveOption.FILE_OVERWRITES_BLOCKED
-        )
+        assert kwargs["overwrite_option"] == DatastoreSaveOption.FILE_OVERWRITES_BLOCKED
 
     @pytest.mark.asyncio
     async def test_allowed_overwrite_option_is_forwarded(self):
@@ -482,7 +475,5 @@ class TestPollScienceFlowOverwriteOption:
                 overwrite_option=DatastoreSaveOption.FILE_OVERWRITES_ALLOWED,
             )
 
-        # Verify the allowed option was forwarded positionally (last positional arg)
-        assert (
-            mock_batch.call_args.args[-1] == DatastoreSaveOption.FILE_OVERWRITES_ALLOWED
-        )
+        _, kwargs = mock_batch.call_args
+        assert kwargs["overwrite_option"] == DatastoreSaveOption.FILE_OVERWRITES_ALLOWED

--- a/tests/unit/test_pollScience.py
+++ b/tests/unit/test_pollScience.py
@@ -173,7 +173,7 @@ class TestPollScienceFlowUnit:
             )
 
         mock_logger.warning.assert_any_call(
-            "Database cannot be updated without forcing ingestion date. Database will not be updated."
+            "Workflow progress in database cannot be updated without forcing ingestion date. Progress downloading any files will not be recorded so these files may be redownloaded again later in scheduled jobs."
         )
 
     @pytest.mark.asyncio

--- a/tests/unit/test_pollScience.py
+++ b/tests/unit/test_pollScience.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from imap_mag.config import DatastoreSaveOption
 from imap_mag.util import ScienceLevel, ScienceMode
 from prefect_server.pollScience import (
     _download_batch_of_science,
@@ -362,3 +363,126 @@ class TestPollScienceFlowGenerateName:
             name = generate_flow_run_name()
 
         assert "01-06-2025" in name
+
+
+class TestDownloadBatchOverwriteOption:
+    """Tests that overwrite_option is forwarded from _download_batch_of_science to fetch_science."""
+
+    def _call_batch(self, overwrite_option: DatastoreSaveOption, mock_fetch):
+        return _download_batch_of_science(
+            level=MagicMock(),
+            reference_frames=None,
+            modes=None,
+            start_date=datetime(2025, 1, 1),
+            end_date=datetime(2025, 1, 31),
+            logger=MagicMock(),
+            database=MagicMock(),
+            use_database=False,
+            use_ingestion_date=False,
+            progress_item_id="TEST_L1C",
+            packet_start_timestamp=datetime(2025, 1, 1),
+            batch_size=10,
+            skip_items_count=0,
+            overwrite_option=overwrite_option,
+        )
+
+    def test_blocked_option_is_forwarded_to_fetch_science(self):
+        with patch(
+            "prefect_server.pollScience.fetch_science", return_value={}
+        ) as mock_fetch:
+            self._call_batch(DatastoreSaveOption.FILE_OVERWRITES_BLOCKED, mock_fetch)
+
+        _, kwargs = mock_fetch.call_args
+        assert kwargs["overwrite_option"] == DatastoreSaveOption.FILE_OVERWRITES_BLOCKED
+
+    def test_allowed_option_is_forwarded_to_fetch_science(self):
+        with patch(
+            "prefect_server.pollScience.fetch_science", return_value={}
+        ) as mock_fetch:
+            self._call_batch(DatastoreSaveOption.FILE_OVERWRITES_ALLOWED, mock_fetch)
+
+        _, kwargs = mock_fetch.call_args
+        assert kwargs["overwrite_option"] == DatastoreSaveOption.FILE_OVERWRITES_ALLOWED
+
+
+class TestPollScienceFlowOverwriteOption:
+    """Tests that poll_science_flow accepts overwrite_option and passes it through."""
+
+    def _make_mocks(self):
+        mock_logger = MagicMock()
+        mock_dm = MagicMock()
+        mock_dm.get_dates_for_download.return_value = (
+            datetime(2025, 1, 1),
+            datetime(2025, 1, 31),
+        )
+        return mock_logger, mock_dm
+
+    @pytest.mark.asyncio
+    async def test_blocked_is_the_default_overwrite_option(self):
+        mock_logger, mock_dm = self._make_mocks()
+
+        with (
+            patch(
+                "prefect_server.pollScience.try_get_prefect_logger",
+                return_value=mock_logger,
+            ),
+            patch("prefect_server.pollScience.Database", return_value=MagicMock()),
+            patch(
+                "prefect_server.pollScience.get_secret_or_env_var", return_value="code"
+            ),
+            patch(
+                "prefect_server.pollScience.DownloadDateManager", return_value=mock_dm
+            ),
+            patch(
+                "prefect_server.pollScience._download_batch_of_science",
+                return_value={},
+            ) as mock_batch,
+            patch("asyncio.sleep"),
+        ):
+            await poll_science_flow.fn(
+                start_date=datetime(2025, 1, 1),
+                end_date=datetime(2025, 1, 31),
+            )
+
+        _, kwargs = mock_batch.call_args
+        assert kwargs.get(
+            "overwrite_option", ...
+        ) == DatastoreSaveOption.FILE_OVERWRITES_BLOCKED or (
+            # positional call: overwrite_option is the last positional arg (index 14)
+            mock_batch.call_args.args
+            and mock_batch.call_args.args[-1]
+            == DatastoreSaveOption.FILE_OVERWRITES_BLOCKED
+        )
+
+    @pytest.mark.asyncio
+    async def test_allowed_overwrite_option_is_forwarded(self):
+        mock_logger, mock_dm = self._make_mocks()
+
+        with (
+            patch(
+                "prefect_server.pollScience.try_get_prefect_logger",
+                return_value=mock_logger,
+            ),
+            patch("prefect_server.pollScience.Database", return_value=MagicMock()),
+            patch(
+                "prefect_server.pollScience.get_secret_or_env_var", return_value="code"
+            ),
+            patch(
+                "prefect_server.pollScience.DownloadDateManager", return_value=mock_dm
+            ),
+            patch(
+                "prefect_server.pollScience._download_batch_of_science",
+                return_value={},
+            ) as mock_batch,
+            patch("asyncio.sleep"),
+        ):
+            await poll_science_flow.fn(
+                start_date=datetime(2025, 1, 1),
+                end_date=datetime(2025, 1, 31),
+                overwrite_option=DatastoreSaveOption.FILE_OVERWRITES_ALLOWED,
+            )
+
+        # Verify the allowed option was forwarded positionally (last positional arg)
+        assert (
+            mock_batch.call_args.args[-1] == DatastoreSaveOption.FILE_OVERWRITES_ALLOWED
+        )

--- a/tests/unit/test_spice.py
+++ b/tests/unit/test_spice.py
@@ -197,6 +197,7 @@ class TestFetchSpice:
         mock_output_manager.add_file.return_value = (
             mock_output_file,
             mock_output_handler,
+            False,
         )
         mock_settings = _make_mock_fetch_spice_settings(tmp_path)
         mock_settings.fetch_spice.publish_to_data_store = True
@@ -246,7 +247,7 @@ class TestPublishSpiceKernel:
         kernel_path.write_text("kernel content")
         output_file = tmp_path / "datastore" / "spice" / "sclk" / "imap_sclk_0001.tsc"
         mock_output_manager = MagicMock()
-        mock_output_manager.add_file.return_value = (output_file, MagicMock())
+        mock_output_manager.add_file.return_value = (output_file, MagicMock(), False)
 
         with (
             patch(


### PR DESCRIPTION
## Summary

- Adds a new \`DatastoreSaveOption\` enum (\`FILE_OVERWRITES_BLOCKED\` / \`FILE_OVERWRITES_ALLOWED\`) to control how the datastore handles a downloaded SDC science file whose version matches an existing file but whose content has changed.
- Wires the new \`overwrite_option\` parameter through \`poll_science_flow\` → \`_download_batch_of_science\` → \`fetch_science\` so it can be set per flow run.
- **Default is \`FILE_OVERWRITES_BLOCKED\`**, which preserves the existing error-on-conflict behaviour (\`version_is_locked\` raises \`ValueError\`).
- When \`FILE_OVERWRITES_ALLOWED\`, the handler gets \`allow_overwrite=True\` set (declared as an explicit field on \`SequenceablePathHandler\`). \`version_is_locked\` remains \`True\` — the SDC-assigned version number is authoritative and never changed. The \`allow_overwrite\` flag causes the existing overwrite infrastructure in \`DatastoreFileManager\` / \`DBIndexedDatastoreFileManager\` to replace the file in place at the same version without incrementing, and to update the DB record hash and \`last_modified_date\`.