### PR TITLE
Feature to upload calculated_offsets to Box

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,11 +21,11 @@ repos:
       - id: remove-crlf
       - id: remove-tabs
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: "0.37.4"
+    rev: "0.38.0"
     hooks:
       - id: check-github-workflows
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.16.1
+    rev: v0.16.2
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/imap-mag-config.yaml
+++ b/imap-mag-config.yaml
@@ -164,6 +164,8 @@ upload:
         - "*ialirt_hk/*"
         - "*quicklook/*"
         - "*spice/*"
+        - "*calibration/calculated_offsets/spin_plane/*"
+        - "*calibration/calculated_offsets/spin_optimised/*"
 
 postgres_upload:
     crump_config_path: imap-db-ingest-config.yaml


### PR DESCRIPTION
As we move towards running the calibration fully in the pipeline, I would like the spin plane calculated_offsets to sync to Box so that they are easy for members of the team to view and plot.